### PR TITLE
Remove redundant name qualifier for "type" fields.

### DIFF
--- a/people.md
+++ b/people.md
@@ -39,7 +39,7 @@
 |----------------|-----------|----------------
 | primary		| boolean	|Denotes if this is the primary address.  A person can have only one primary address
 | address		| string	| The actual email address according to RFC822
-| address_type	| string	| Flexenum of Home, Work, Other
+| type	| string	| Flexenum of Personal, Work, Other
 
 # Phone Numbers
 | Name          | Type      | Description
@@ -48,7 +48,7 @@
 | number		| string	| The actual phone number which MUST including country code and MUST be numeric characters only 
 | extension		| string	| Optional associated extension
 | description	| string	| Optional Free form additional text description
-| phone_type	| string	| flexnum of Home, Work, Mobile, Other, Daytime, Evening, Fax
+| type	| string	| flexnum of Home, Work, Mobile, Other, Daytime, Evening, Fax
 | operator		| string	| Optional: Operator/Carrier associated with number, eg "Verizon"
 | country		| string	| Country code according to ISO 3166-1 Alpha-2
 | sms_capable	| boolean	| True if the number can accept sms text messages


### PR DESCRIPTION
A field name like phone_type within a phone number doesn't need the phone_ prefix.
