### PR TITLE
Transport: "combolining" proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,7 +489,7 @@ POST /api/v1/1828182/donations
 When the server processes a `DonationCreate`, the following things happen
 1. A Donation resource is created
 2. A person resource is created or merged based on provided information
-3. If transactional is supported, then a donation_transaction is created containing the exact data contained in the DonationCreate representation
+3. If transactional is supported, then a transaction_donor is created containing the exact data contained in the DonationCreate representation
 
 Response
 The server shall respond to a DonationCreate with a Donation representation
@@ -506,8 +506,7 @@ The server shall respond to a DonationCreate with a Donation representation
 			"family_name" : "McTesterson",
 			... other person attributes
 		},
-		"osdi:donation_transaction" : {
-			"person" : {
+		"osdi:transaction_donor" : {
 				"given_name" : "Testy",
 				"family_name" : "McTesterson",
 				... other person attributes
@@ -517,13 +516,9 @@ The server shall respond to a DonationCreate with a Donation representation
 		"osdi:person" : {
 			"href": "http://server/path/to/person"
 		},
-		"osdi:donation_transaction" : {	
-			"href": "http://path/to/donation_transaction",
+		"osdi:transaction_donor" : {	
+			"href": "http://path/to/transaction_donor",
 		},
-		"osdi:set_person" : {
-			"href": "http://path/to/donation/5/set_person"
-		},
-
 		... other links
 	}
 }
@@ -537,17 +532,17 @@ A client sends a GET on the donations collection or an individual donation recor
 Updating Data
 A client sends a PUT or PATCH to an individual Donation resource
 
-### Working with DonationTransaction Resources
+### Working with TransactionDonor Resources
 By having a separate donation transaction resource, we can customize this at will or even cherry pick data from other resources.
 
 If a system does not support transactional data, then there is no complexity to the models.  It just does not show up in _embedded or _linked
 
 Reading data
 
-A client sends a GET on the DonationTransaction collection or an individual donation record
+A client sends a GET on the TransactionDonor collection or an individual donation record
 
 Updating Data
-A client sends a PUT or PATCH to an individual DonationTransaction resource
+A client sends a PUT or PATCH to an individual TransactionDonor resource
 
 ## Changing an association
 


### PR DESCRIPTION
combo-lining proposal. An evolved actions proposal with link-setting that gives relational data priority while allowing a clean way for extensions like transactional data
- Assertion: Relational is the common case and transactional is the exception and therefore transactional needs to be optional
- When using OSDI relationally, attributes and other data should be in the easy and obvious places, behavior should be intuitive as if transactional did not exist.
- Transactional should be defined in such a way that it could have been written as an OSDI extension specification
- Create representations have inlined resources like person.  This avoids composite update complexity
- when reading resources a standard HAL response representation is used where associated resources are linked and optionally _embedded
- when updating a resource with PUT or PATCH, only the attributes of the targeted resource are included.  Updating an associated resource must be done directly on that resource.
- Assertion: Transactional data is known/created by the server not the client.  The Create representation just contains 1 person information.  If the server supports transactional data, then it will create the donation_transaction resource.
- Transactional data is cleanly layered in if the implementation supports it.  It is a separate resource that can be linked to and embedded in a donation resource retrieval. 
  - The embedding of donation_transaction allows the client to get both pieces of data in the same request if it wishes to.
- While this proposal prioritizes Relational data, when transactional is implemented and in use, it's person shows up as an embedded peer to the relational person.
- Assertion: Criticality of changing associations is fairly rare.  Most of the time you can just delete a resource and recreate it.  However there are some exceptions where it is needed.  We should have a pattern for this that is narrow in scope to minimize server complexity.
- Changing an association (say reassigning an event to a different organizer) is achieved by link relations like "osdi:set_organizer" on an individual event resource
