### PR TITLE
PROPOSAL: Petition action type

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Please give us feedback on our work. [Read the Review Guide](review_guide.md) to
 * Charles Parsons, Salsa Labs
 * Rich Ranallo, Revolution Messaging
 * Jason Rosenbaum, The Action Network
+* Gustavo Costa, The Action Network
 * Ben Stein, Mobile Commons
 * Ray Suelzer, UFCW International Union
 * Brian Vallelunga, Trilogy Interactive (Editor)

--- a/petitions.md
+++ b/petitions.md
@@ -1,6 +1,8 @@
 # Petitions
 
-This page defines Petitions, Petition Signatures
+This page defines Petitions, Petition Signatures.
+
+Petitions are actions that have a target. Activists are asked to sign the petition to add their name to a common letter directed at the target.
 
 ## Petitions
 


### PR DESCRIPTION
We've developed a petition action type to compliment our other action types (like events, for instance), that we want to contribute back as part of the spec.

Petitions follow a lot of the same conventions as events, but they represent petition actions. They have various fields of metadata about themselves (such as the target of the petition) and then they have signature resources to represent each signing transaction, the signer person object, and their comments on signing.

The new fields we'd be proposing are:

target -- an array of hashes representing the target(s) of the petition. Right now, we're only using name in the hash, but open to suggestions for other parts of a target hash that would be useful.

petition_text -- the actual text of the letter to the target, different from the summary and description, which are usually more signer focused (call to action, etc...)

We're also incorporating the proposal we have open in issue #107.
