### PR TITLE
Advocacy proposal

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -2,6 +2,7 @@
     <li class="nav-header">Getting Started</li>
     <li><a href="{{ site.baseurl }}/">Introduction</a></li>
     <li class="nav-header">Resources</li>
+    <li><a href="{{ site.baseurl }}/advocacy_campaigns.html">Advocacy Campaigns</a></li>
     <li><a href="{{ site.baseurl }}/aep.html">API Entry Point</a></li>
     <li><a href="{{ site.baseurl }}/answers.html">Answers</a></li>
     <li><a href="{{ site.baseurl }}/attendances.html">Attendances</a></li>
@@ -11,6 +12,7 @@
     <li><a href="{{ site.baseurl }}/fundraising_pages.html">Fundraising Pages</a></li>
     <li><a href="{{ site.baseurl }}/items.html">Items</a></li>
     <li><a href="{{ site.baseurl }}/lists.html">Lists</a></li>
+    <li><a href="{{ site.baseurl }}/outreaches.html">Outreaches</a></li>
     <li><a href="{{ site.baseurl }}/people.html">People</a></li>
     <li><a href="{{ site.baseurl }}/petitions.html">Petitions</a></li>
     <li><a href="{{ site.baseurl }}/queries.html">Queries</a></li>
@@ -24,6 +26,7 @@
     <li><a href="{{ site.baseurl }}/person_signup.html">Person Signup Helper</a></li>
     <li><a href="{{ site.baseurl }}/record_attendance.html">Record Attendance Helper</a></li>
     <li><a href="{{ site.baseurl }}/record_donation.html">Record Donation Helper</a></li>
+    <li><a href="{{ site.baseurl }}/record_outreach.html">Record Outreach Helper</a></li>
     <li><a href="{{ site.baseurl }}/record_signature.html">Record Signature Helper</a></li>
     <li><a href="{{ site.baseurl }}/record_submission.html">Record Submission Helper</a></li>
 </ul>

--- a/advocacy_campaigns.md
+++ b/advocacy_campaigns.md
@@ -1,0 +1,421 @@
+---
+layout: default
+title: Advocacy Campaign
+---
+
+# Advocacy Campaign
+
+This document defines the Advocacy Campaign resource. 
+
+Advocacy campaigns represent an advocacy action directed at targets such as elected officials that a user may participate in by contacting those officials in some way, such as via email or phone. Advocacy campaigns have fields to describe them such as names, titles, summaries, descriptions, and targeting information, and when activists participate in an advocacy campaign, [Outreach](outreaches.html) resources are created representing the individual outreach an activist made to a target as part of that advocacy campaign.
+
+
+### Sections
+
+* [Endpoints and URL structures](#endpoints-and-url-structures)
+* [Fields](#fields)
+    * [Common Fields](#common-fields)
+    * [Advocacy Campaign Fields](#advocacy-campaign-fields)  
+    * [Links](#links)
+* [Related Resources](#related-resources)
+* [Scenarios](#scenarios)
+    * [Scenario: Retrieving a collection of Advocacy Campaign resources (GET)](#scenario-retrieving-a-collection-of-advocacy-campaign-resources-get)
+    * [Scenario: Retrieving an individual Advocacy Campaign resource (GET)](#scenario-scenario-retrieving-an-individual-advocacy-campaign-resource-get)
+    * [Scenario: Creating a new advocacy campaign (POST)](#scenario-creating-a-new-advocacy-campaign-post)
+    * [Scenario: Modifying an advocacy campaign (PUT)](#scenario-modifying-an-advocacy-campaign-put)
+    * [Scenario: Deleting an advocacy campaign (DELETE)](#scenario-deleting-an-advocacy-campaign-delete)
+
+
+{% include endpoints_and_url_structures.md %}
+
+The link relation label for an Advocacy Campaign resource is ```osdi:advocacy_campaign``` for a single Advocacy Campaign resource or ```osdi:advocacy_campaigns``` for a collection of Advocacy Campaign resources.
+
+_[Back to top...](#)_
+
+
+## Fields
+
+{% include fields_intro.md %}
+
+{% include global_fields.md %}
+
+_[Back to top...](#)_
+
+
+### Advocacy Campaign Fields
+
+A list of fields specific to the Advocacy Campaign resource.
+
+| Name          | Type      | Description
+|-----------    |-----------|-----------|--------------
+|origin_system		|string     |A human readable identifier of the system where this advocacy campaign was created. (ex: "OSDI System")
+|name				|string		|The name of the advocacy campaign. Intended for administrative display rather than a public title, though may be shown to a user.
+|title				|string		|The title of the advocacy campaign. Intended for public display rather than administrative purposes.
+|description		|string		|A description of the advocacy campaign, usually displayed publicly. May contain text and/or HTML.
+|summary			|string		|A text-only single paragraph summarizing the advocacy campaign. Shown on listing pages that have more than titles, but not enough room for full description.
+|targets			|string		|A human readable description of the target universe for this advocacy campaign. (ex: "U.S. Congress")
+|browser_url		|string		|A URL string pointing to the publicly available advocacy campaign page on the web.
+|total_outreaches	|integer	|A read-only computed property representing the current count of the total number of outreaches on the advocacy campaign.
+|type				|flexunum	|The type of advocacy campaign, specifying how users perform outreaches to targets. One of "email", "in-person", "phone", "postal mail", or another type as needed.
+
+_[Back to top...](#)_
+
+
+### Links
+
+{% include links_intro.md %}
+
+| Name          | Type      | Description
+|-----------    |-----------|-----------|--------------
+|self			|[Advocacy Campaigns*](advocacy_campaigns.html)	|A self-referential link to the advocacy campaign.
+|creator		|[Person*](people.html)  		|A link to a single Person resource representing the creator of the advocacy campaign.
+|modified_by	|[Person* ](people.html) 		|A link to a Person resource representing the last editor of this advocacy campaign.
+|signatures		|[Outreaches[]*](outreaches.html)	|A link to the collection of Outreach resources for this advocacy campaign.
+|record_outreach_helper	|[Record Outreach Helper*](record_outreach.html)	|A link to the Record Outreach Helper resource endpoint for this advocacy campaign.
+
+_[Back to top...](#)_
+
+
+## Related Resources
+
+* [Outreaches](outreaches.html)
+* [Record Outreach Helper](record_outreach.html)
+* [Person](people.html)
+
+_[Back to top...](#)_
+
+## Scenarios
+
+{% include scenarios_intro.md %}
+
+### Scenario: Retrieving a collection of Advocacy Campaign resources (GET)
+
+Advocacy campaign resources are sometimes presented as collections of advocacy campaigns. For example, calling the advocacy campaigns endpoint will return a collection of all the advocacy campaigns stored in the system's database associated with your api key.
+
+#### Request
+
+```javascript
+GET https://osdi-sample-system.org/api/v1/advocacy_campaigns/
+
+Header:
+OSDI-API-Token:[your api key here]
+```
+
+#### Response
+
+```javascript
+200 OK
+
+Content-Type: application/hal+json
+Cache-Control: max-age=0, private, must-revalidate
+
+{
+    "total_pages": 10,
+    "per_page": 25,
+    "page": 1,
+    "total_records": 250,
+    "_links": {
+        "next": {
+            "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns?page=2"
+        },
+        "osdi:advocacy_campaigns": [
+            {
+                "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3"
+            },
+            {
+                "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns/1efc3644-af25-4253-90b8-a0baf12dbd1e"
+            },
+            //(truncated for brevity)
+        ],
+        "curies": [
+            {
+                "name": "osdi",
+                "href": "https://osdi-sample-system.org/docs/v1/{rel}",
+                "templated": true
+            }
+        ],
+        "self": {
+            "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns"
+        }
+    },
+    "_embedded": {
+        "osdi:advocacy_campaigns": [
+            {
+                "identifiers": [
+                    "osdi_sample_system:d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3",
+                    "foreign_system:1"
+                ],
+                "origin_system": "OSDI Sample System",
+                "created_date": "2014-03-20T21:04:31Z",
+                "modified_date": "2014-03-20T21:04:31Z",
+                "name": "Civil Rights Bill 2015 Advocacy Campaign",
+                "title": "Tell Congress to pass the 2015 Civil Rights bill",
+                "description": "<p>Congress is prepared to pass a civil rights bill.</p><p>Email your member of Congress and tell them to vote yes!</p>",
+                "summary": "Congress is prepared to pass a civil rights bill -- tell your member of Congress to vote yes.",
+                "target_universe": "U.S. Congress",
+                "browser_url": "http://osdi-sample-system.org/advocacy_campaigns/civil-rights-2015",
+                "type": "email",
+                "total_outreaches": 345,
+                "_links": {
+                    "self": {
+                        "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3"
+                    },
+                    "osdi:outreaches": {
+                        "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/outreaches"
+                    },
+                    "osdi:creator": {
+                        "href": "https://osdi-sample-system.org/api/v1/people/65345d7d-cd24-466a-a698-4a7686ef684f"
+                    },
+                    "osdi:modified_by": {
+                        "href": "https://osdi-sample-system.org/api/v1/people/c945d6fe-929e-11e3-a2e9-12313d316c29"
+                    },
+                    "osdi:record_outreach_helper": {
+                        "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/record_outreach_helper"
+                    }
+                }
+            },
+            {
+                "identifiers": [
+                    "osdi_sample_system:1efc3644-af25-4253-90b8-a0baf12dbd1e"
+                ],
+                "origin_system": "OSDI Sample System",
+                "created_date": "2014-03-20T20:44:13Z",
+                "modified_date": "2014-03-20T20:44:13Z",
+                "title": "Call Congress: Raise the minimum wage!",
+                "description": "<p>We need $15/hour now!</p>",
+                "target_universe": "U.S. Senate",
+                "browser_url": "http://osdi-sample-system.org/advocacy_campaigns/raise-the-wage",
+                "type": "phone"
+                "total_outreaches": 10572,
+                "_links": {
+                    "self": {
+                        "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns/1efc3644-af25-4253-90b8-a0baf12dbd1e"
+                    },
+                    "osdi:outreaches": {
+                        "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns/1efc3644-af25-4253-90b8-a0baf12dbd1e/outreaches"
+                    },
+                    "osdi:creator": {
+                        "href": "https://osdi-sample-system.org/api/v1/people/65345d7d-cd24-466a-a698-4a7686ef684f"
+                    },
+                    "osdi:modified_by": {
+                        "href": "https://osdi-sample-system.org/api/v1/people/65345d7d-cd24-466a-a698-4a7686ef684f"
+                    },
+                    "osdi:record_outreach_helper": {
+                        "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns/1efc3644-af25-4253-90b8-a0baf12dbd1e/record_outreach_helper"
+                    }
+                }
+            },
+            //(truncated for brevity)
+        ]
+    }
+}
+```	
+
+_[Back to top...](#)_		
+
+### Scenario: Scenario: Retrieving an individual Advocacy Campaign resource (GET)
+
+Calling an individual Advocacy Campaign resource will return the resource directly, along with all associated fields and appropriate links to additional information about the advocacy campaign.
+
+#### Request
+
+```javascript
+GET https://osdi-sample-system.org/api/v1/advocacy_campaigns/d32fcdd6-7366-466d-a3b8-7e0d87c3cd8b
+
+Header:
+OSDI-API-Token:[your api key here]
+```
+
+#### Response
+
+```javascript
+200 OK
+
+Content-Type: application/hal+json
+Cache-Control: max-age=0, private, must-revalidate
+
+{
+    "identifiers": [
+        "osdi_sample_system:d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3",
+        "foreign_system:1"
+    ],
+    "origin_system": "OSDI Sample System",
+    "created_date": "2014-03-20T21:04:31Z",
+    "modified_date": "2014-03-20T21:04:31Z",
+    "name": "Civil Rights Bill 2015 Advocacy Campaign",
+    "title": "Tell Congress to pass the 2015 Civil Rights bill",
+    "description": "<p>Congress is prepared to pass a civil rights bill.</p><p>Email your member of Congress and tell them to vote yes!</p>",
+    "summary": "Congress is prepared to pass a civil rights bill -- tell your member of Congress to vote yes.",
+    "target_universe": "U.S. Congress",
+    "browser_url": "http://osdi-sample-system.org/advocacy_campaigns/civil-rights-2015",
+    "type": "email",
+    "total_outreaches": 345,
+    "_links": {
+        "self": {
+            "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3"
+        },
+        "osdi:outreaches": {
+            "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/outreaches"
+        },
+        "osdi:creator": {
+            "href": "https://osdi-sample-system.org/api/v1/people/65345d7d-cd24-466a-a698-4a7686ef684f"
+        },
+        "osdi:modified_by": {
+            "href": "https://osdi-sample-system.org/api/v1/people/c945d6fe-929e-11e3-a2e9-12313d316c29"
+        },
+        "osdi:record_outreach_helper": {
+            "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/record_outreach_helper"
+        }
+    }
+}
+```
+
+_[Back to top...](#)_
+
+
+### Scenario: Creating a new advocacy campaign (POST)
+
+Posting to the advocacy campaign collection endpoint will allow you to create a new advocacy campaign. The response is the new advocacy campaign that was created. While each implementing system will require different fields, any optional fields not included in a post operation should not be set at all by the receiving system, or should be set to default values.
+
+#### Request
+
+```javascript
+POST https://osdi-sample-system.org/api/v1/advocacy_campaigns/
+
+Header:
+OSDI-API-Token:[your api key here]
+
+{
+    "identifiers": [
+        "foreign_system:1"
+    ],
+    "name": "Civil Rights Bill 2015 Advocacy Campaign",
+    "title": "Tell Congress to pass the 2015 Civil Rights bill",
+    "origin_system": "OpenSupporter"
+}
+```
+
+#### Response
+
+```javascript
+200 OK
+
+Content-Type: application/hal+json
+Cache-Control: max-age=0, private, must-revalidate
+
+{
+    "identifiers": [
+        "osdi_sample_system:d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3",
+        "foreign_system:1"
+    ],
+    "origin_system": "OpenSupporter",
+    "created_date": "2014-03-20T21:04:31Z",
+    "modified_date": "2014-03-20T21:04:31Z",
+    "name": "Civil Rights Bill 2015 Advocacy Campaign",
+    "title": "Tell Congress to pass the 2015 Civil Rights bill",
+    "total_outreaches": 0,
+    "_links": {
+        "self": {
+            "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3"
+        },
+        "osdi:outreaches": {
+            "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/outreaches"
+        },
+        "osdi:creator": {
+            "href": "https://osdi-sample-system.org/api/v1/people/65345d7d-cd24-466a-a698-4a7686ef684f"
+        },
+        "osdi:record_outreach_helper": {
+            "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/record_outreach_helper"
+        }
+    }
+}
+```
+
+_[Back to top...](#)_
+
+
+### Scenario: Modifying an advocacy campaign (PUT)
+
+You can update an advocacy campaign by calling a PUT operation on that advocacy campaign's endpoint. Your PUT should contain fields that you want to update. Missing fields will be ignored by the receiving system. Systems may also ignore PUT values, depending on whether fields you are trying to modify are read-only or not. You may set an attribute to nil by including the attribute using `nil` for value.
+
+{% include array_warning.md %}
+
+#### Request
+
+```javascript
+PUT https://osdi-sample-system.org/api/v1/advocacy_campaigns/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse
+
+Header:
+OSDI-API-Token:[your api key here]
+
+{
+    "name": "Civil Rights Bill 2015-2016 Advocacy Campaign"
+}
+
+```
+
+#### Response
+```javascript
+200 OK
+
+Content-Type: application/hal+json
+Cache-Control: max-age=0, private, must-revalidate
+
+{
+    "identifiers": [
+        "osdi_sample_system:d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3",
+        "foreign_system:1"
+    ],
+    "origin_system": "OpenSupporter",
+    "created_date": "2014-03-20T21:04:31Z",
+    "modified_date": "2014-03-20T22:04:31Z",
+    "name": "Civil Rights Bill 2015-2016 Advocacy Campaign",
+    "title": "Tell Congress to pass the 2015 Civil Rights bill",
+    "total_signatures": 0,
+    "_links": {
+        "self": {
+            "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3"
+        },
+        "osdi:outreaches": {
+            "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/outreaches"
+        },
+        "osdi:creator": {
+            "href": "https://osdi-sample-system.org/api/v1/people/65345d7d-cd24-466a-a698-4a7686ef684f"
+        },
+        "osdi:record_outreach_helper": {
+            "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/record_outreach_helper"
+        }
+    }
+}
+```
+
+_[Back to top...](#)_
+
+
+### Scenario: Deleting an advocacy campaign (DELETE)
+
+You may delete an advocacy campaign by calling the DELETE command on the advocacy campaign's endpoint.
+
+#### Request
+
+```javascript
+DELETE https://osdi-sample-system.org/api/v1/advocacy_campaigns/d32fcdd6-7366-466d-a3b8-7e0d87c3cd8b
+
+Header:
+OSDI-API-Token:[your api key here]
+```
+
+#### Response
+
+```javascript
+200 OK
+
+Content-Type: application/hal+json
+Cache-Control: max-age=0, private, must-revalidate
+
+{
+    "notice": "This advocacy campaign was successfully deleted."
+}
+```
+
+_[Back to top...](#)_

--- a/donations.md
+++ b/donations.md
@@ -51,7 +51,7 @@ _[Back to top...](#)_
 |credited_amount|number		| Amount credited back to donor in specified currency.
 |credited_date	|datetime	| Date of the credit.
 |currency		|string		| ISO 4217 designation of currency. Example: USD, JPY
-|recipients		|[Recipient](#recipient)[]| Array of recipients associated with the donation.
+|recipients		|[Recipient[]](#recipient)[]| Array of recipients associated with the donation.
 |payment		|[Payment](#payment)	| The payment details.
 |subscription_instance|string| A sequence number or some other value unique to this instance of the donation in the context of a subscription. Examples: 5, JAN-2014
 |voided			|boolean	|Indicates if the donation has been voided.

--- a/outreaches.md
+++ b/outreaches.md
@@ -144,7 +144,7 @@ Cache-Control: max-age=0, private, must-revalidate
         "next": {
             "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns/c945d6fe-929e-11e3-a2e9-12313d316c29/outreaches?page=2"
         },
-        "osdi:signatures": [
+        "osdi:outreaches": [
             {
                 "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns/c945d6fe-929e-11e3-a2e9-12313d316c29/outreaches/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3"
             },

--- a/outreaches.md
+++ b/outreaches.md
@@ -69,7 +69,8 @@ These JSON hashes included in the table above are broken out into their own tabl
 
 |Name          	|Type      |Description
 |-----------    |-----------|--------------
-|target.title	|string    |The title of the target. (ex: "Senator")
+|target.title	|string    |The title or position of the target. (ex: "Senator" or "CEO")
+|target.organization	|string	|The organization the target belongs to. (ex: "U.S. Senate" or "Acme Corporation")
 |target.given_name	|string    |The first or given name of the target. (ex: "John")
 |target.family_name	|string    |The last or family name of the target. (ex: "Smith")
 |target.ocdid	|string    |The Open Civic Data Division ID for this target's political geography, if applicable. See [here](http://docs.opencivicdata.org/en/latest/proposals/0002.html) for more documentation. (ex: "ocd-division/country:us/state:ny/cd:18", which corresponds to New York's 18th Congressional District)
@@ -182,12 +183,14 @@ Cache-Control: max-age=0, private, must-revalidate
 	                    "title": "Senator",
 	                    "given_name": "John",
 	                    "family_name": "Smith",
+	                    "organization": "U.S. Senate",
 	                    "ocdid": "ocd-division/country:us/state:ny"
 	                },
 	                {
 	                    "title": "Senator",
 	                    "given_name": "Jennifer",
 	                    "family_name": "Larson",
+	                    "organization": "U.S. Senate",
 	                    "ocdid": "ocd-division/country:us/state:ny"
 	                }
 	            ],
@@ -219,6 +222,7 @@ Cache-Control: max-age=0, private, must-revalidate
 	                    "title": "Senator",
 	                    "given_name": "Jane",
 	                    "family_name": "Doe",
+	                    "organization": "U.S. Senate",
 	                    "ocdid": "ocd-division/country:us/state:va"
 	                }
 	            },
@@ -280,12 +284,14 @@ Cache-Control: max-age=0, private, must-revalidate
 	        "title": "Senator",
 	        "given_name": "John",
 	        "family_name": "Smith",
+	        "organization": "U.S. Senate",
 	        "ocdid": "ocd-division/country:us/state:ny"
 	    },
 	    {
 	        "title": "Senator",
 	        "given_name": "Jennifer",
 	        "family_name": "Larson",
+	        "organization": "U.S. Senate",
 	        "ocdid": "ocd-division/country:us/state:ny"
 	    }
 	],
@@ -333,12 +339,14 @@ OSDI-API-Token:[your api key here]
 	        "title": "Senator",
 	        "given_name": "John",
 	        "family_name": "Smith",
+	        "organization": "U.S. Senate",
 	        "ocdid": "ocd-division/country:us/state:ny"
 	    },
 	    {
 	        "title": "Senator",
 	        "given_name": "Jennifer",
 	        "family_name": "Larson",
+	        "organization": "U.S. Senate",
 	        "ocdid": "ocd-division/country:us/state:ny"
 	    }
 	],
@@ -373,12 +381,14 @@ Cache-Control: max-age=0, private, must-revalidate
 	        "title": "Senator",
 	        "given_name": "John",
 	        "family_name": "Smith",
+	        "organization": "U.S. Senate",
 	        "ocdid": "ocd-division/country:us/state:ny"
 	    },
 	    {
 	        "title": "Senator",
 	        "given_name": "Jennifer",
 	        "family_name": "Larson",
+	        "organization": "U.S. Senate",
 	        "ocdid": "ocd-division/country:us/state:ny"
 	    }
 	],
@@ -441,12 +451,14 @@ Cache-Control: max-age=0, private, must-revalidate
 	        "title": "Senator",
 	        "given_name": "John",
 	        "family_name": "Smith",
+	        "organization": "U.S. Senate",
 	        "ocdid": "ocd-division/country:us/state:ny"
 	    },
 	    {
 	        "title": "Senator",
 	        "given_name": "Jennifer",
 	        "family_name": "Larson",
+	        "organization": "U.S. Senate",
 	        "ocdid": "ocd-division/country:us/state:ny"
 	    }
 	],

--- a/outreaches.md
+++ b/outreaches.md
@@ -1,0 +1,454 @@
+---
+layout: default
+title: Outreach
+---
+
+# Outreach
+
+This document defines the Outreach resource. 
+
+Outreachs are a type of action that a user may take by participating in an advocacy campaign. Outreachs have fields to describe them such as when the outreach was created, who the user contacted as the target of their advocacy, and the content of the message a user sent to that target, and typically are linked to the person who made the outreach.
+
+
+### Sections
+
+* [Endpoints and URL structures](#endpoints-and-url-structures)
+* [Fields](#fields)
+    * [Common Fields](#common-fields)
+    * [Outreach Fields](#outreach-fields)  
+    * [Related Objects](#related-objects)
+    * [Links](#links)
+* [Helpers](#helpers)
+* [Related Resources](#related-resources)
+* [Scenarios](#scenarios)
+    * [Scenario: Retrieving a collection of Outreach resources (GET)](#scenario-retrieving-a-collection-of-outreach-resources-get)
+    * [Scenario: Retrieving an individual Outreach resource (GET)](#scenario-scenario-retrieving-an-individual-outreach-resource-get)
+    * [Scenario: Creating a new outreach (POST)](#scenario-creating-a-new-outreach-post)
+    * [Scenario: Modifying a outreach (PUT)](#scenario-modifying-a-outreach-put)
+    * [Scenario: Deleting a outreach (DELETE)](#scenario-deleting-a-outreach-delete)
+
+
+{% include endpoints_and_url_structures.md %}
+
+The link relation label for a Outreach resource is ```osdi:outreach``` for a single Outreach resource or ```osdi:outreaches``` for a collection of Outreach resources.
+
+_[Back to top...](#)_
+
+
+## Fields
+
+{% include fields_intro.md %}
+
+{% include global_fields.md %}
+
+_[Back to top...](#)_
+
+
+### Signature Fields
+
+A list of fields specific to the Outreach resource.
+
+| Name          | Type      | Description
+|-----------    |-----------|-----------|--------------
+|origin_system		|string     |A human readable identifier of the system where this outreach was created. (ex: "OSDI System")
+|action_date		|string		|The date and time the outreach was made by the person.
+|type				|flexunum	|The type of outreach, specifying how the user performed the outreach to targets. One of "email", "in-person", "phone", "postal mail", or another type as needed.
+|duration		|integer		|The duration in seconds of the outreach, if applicable. (ex: duration will only be present on phone outreach types)
+|subject		|string		|The subject of the outreach, if applicable. (ex: subject will only be present on email outreach types)
+|message		|string		|The message of the outreach, if applicable. (ex: message will only be present on email or postal mail outreach types)
+|target			|[Target](#target)    |An object hash representing the target of the outreach.
+
+_[Back to top...](#)_
+
+
+### Related Objects
+
+These JSON hashes included in the table above are broken out into their own tables for readability, rather than independent resources with their own endpoints.
+
+#### Target
+
+|Name          	|Type      |Description
+|-----------    |-----------|--------------
+|target.title	|string    |The title of the target. (ex: "Senator")
+|target.given_name	|string    |The first or given name of the target. (ex: "John")
+|target.family_name	|string    |The last or family name of the target. (ex: "Smith")
+|target.ocdid	|string    |The Open Civic Data Division ID for this target's political geography, if applicable. See [here](http://docs.opencivicdata.org/en/latest/proposals/0002.html) for more documentation. (ex: "ocd-division/country:us/state:ny/cd:18", which corresponds to New York's 18th Congressional District)
+
+_[Back to top...](#)_
+
+
+### Links
+
+{% include links_intro.md %}
+
+| Name          | Type      | Description
+|-----------    |-----------|-----------|--------------
+|self			|[Outreach*](outreachs.html)	|A self-referential link to the outreach.
+|person			|[Person*](people.html)		|A link to a single Person resource representing the person who made the outreach.
+|advocacy_campaign		|[Advocacy Campaign*](advocacy_campaigns.html)  		|A link to an Advocacy Campaign resource representing the advocacy campaign on which this outreach was created.
+
+_[Back to top...](#)_
+
+
+## Helpers
+
+{% include helpers_intro.md %}
+
+|Name          |Description
+|-----------    |-----------
+|[record_outreach_helper](record_outreach.html)      |Allows the creation of an outreach and a person at the same time.
+
+_[Back to top...](#)_
+
+
+## Related Resources
+
+* [Record Outreach Helper](record_outreach.html)
+* [Advocacy Campaign](advocacy_campaigns.html)
+* [Person](people.html)
+
+_[Back to top...](#)_
+
+## Scenarios
+
+{% include scenarios_intro.md %}
+
+### Scenario: Retrieving a collection of Outreach resources (GET)
+
+Outreach resources are sometimes presented as collections of outreaches. For example, calling the outreaches endpoint on a particular advocacy campaign will return a collection of all the outreaches made on that advocacy campaign.
+
+#### Request
+
+```javascript
+GET https://osdi-sample-system.org/api/v1/advocacy_campaigns/c945d6fe-929e-11e3-a2e9-12313d316c29/outreaches
+
+Header:
+OSDI-API-Token:[your api key here]
+```
+
+#### Response
+
+```javascript
+200 OK
+
+Content-Type: application/hal+json
+Cache-Control: max-age=0, private, must-revalidate
+
+{
+    "total_pages": 10,
+    "per_page": 25,
+    "page": 1,
+    "total_records": 250,
+    "_links": {
+        "next": {
+            "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns/c945d6fe-929e-11e3-a2e9-12313d316c29/outreaches?page=2"
+        },
+        "osdi:signatures": [
+            {
+                "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns/c945d6fe-929e-11e3-a2e9-12313d316c29/outreaches/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3"
+            },
+            {
+                "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns/c945d6fe-929e-11e3-a2e9-12313d316c29/outreaches/1efc3644-af25-4253-90b8-a0baf12dbd1e"
+            },
+            //(truncated for brevity)
+        ],
+        "curies": [
+            {
+                "name": "osdi",
+                "href": "https://osdi-sample-system.org/docs/v1/{rel}",
+                "templated": true
+            }
+        ],
+        "self": {
+            "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns/c945d6fe-929e-11e3-a2e9-12313d316c29/outreaches"
+        }
+    },
+    "_embedded": {
+        "osdi:outreaches": [
+            {
+                "identifiers": [
+                    "osdi_sample_system:d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3",
+                    "foreign_system:1"
+                ],
+                "origin_system": "OSDI Sample System",
+                "created_date": "2014-03-20T21:04:31Z",
+                "modified_date": "2014-03-20T21:04:31Z",
+                "action_date": "2014-03-18T11:02:15Z",
+                "type": "email",
+                "subject": "Vote no!",
+                "message": "Please vote no on HR 100.",
+                "target": {
+	                "title": "Senator",
+	                "given_name": "John",
+	                "family_name": "Smith",
+	                "ocdid": "ocd-division/country:us/state:ny"
+	            },
+                "_links": {
+                    "self": {
+                        "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns/c945d6fe-929e-11e3-a2e9-12313d316c29/outreaches/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3"
+                    },
+                    "osdi:advocacy_campaign": {
+                        "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns/c945d6fe-929e-11e3-a2e9-12313d316c29"
+                    },
+                    "osdi:person": {
+                        "href": "https://osdi-sample-system.org/api/v1/people/65345d7d-cd24-466a-a698-4a7686ef684f"
+                    }
+                }
+            },
+            {
+                "identifiers": [
+                    "osdi_sample_system:1efc3644-af25-4253-90b8-a0baf12dbd1e"
+                ],
+                "origin_system": "OSDI Sample System",
+                "created_date": "2014-03-20T20:44:13Z",
+                "modified_date": "2014-03-20T20:44:13Z",
+                "action_date": "2014-03-12T01:45:34Z",
+                "type": "email",
+                "subject": "Don't do it!",
+                "message": "Vote no tomorrow!",
+                "target": {
+	                "title": "Senator",
+	                "given_name": "Jane",
+	                "family_name": "doe",
+	                "ocdid": "ocd-division/country:us/state:va"
+	            },
+                "_links": {
+                    "self": {
+                        "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns/c945d6fe-929e-11e3-a2e9-12313d316c29/outreaches/1efc3644-af25-4253-90b8-a0baf12dbd1e"
+                    },
+                    "osdi:advocacy_campaign": {
+                        "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns/c945d6fe-929e-11e3-a2e9-12313d316c29"
+                    },
+                    "osdi:person": {
+                        "href": "https://osdi-sample-system.org/api/v1/people/adb951cb-51f9-420e-b7e6-de953195ec86"
+                    }
+                }
+            },
+            //(truncated for brevity)
+        ]
+    }
+}
+```	
+
+_[Back to top...](#)_		
+
+### Scenario: Scenario: Retrieving an individual Outreach resource (GET)
+
+Calling an individual Outreach resource will return the resource directly, along with all associated fields and appropriate links to additional information about the outreach.
+
+#### Request
+
+```javascript
+GET https://osdi-sample-system.org/api/v1/advocacy_campaigns/c945d6fe-929e-11e3-a2e9-12313d316c29/outreaches/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3
+
+Header:
+OSDI-API-Token:[your api key here]
+```
+
+#### Response
+
+```javascript
+200 OK
+
+Content-Type: application/hal+json
+Cache-Control: max-age=0, private, must-revalidate
+
+{
+    "identifiers": [
+        "osdi_sample_system:d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3",
+        "foreign_system:1"
+    ],
+    "origin_system": "OSDI Sample System",
+    "created_date": "2014-03-20T21:04:31Z",
+    "modified_date": "2014-03-20T21:04:31Z",
+    "action_date": "2014-03-18T11:02:15Z",
+    "type": "email",
+    "subject": "Vote no!",
+    "message": "Please vote no on HR 100.",
+    "target": {
+        "title": "Senator",
+        "given_name": "John",
+        "family_name": "Smith",
+        "ocdid": "ocd-division/country:us/state:ny"
+    },
+    "_links": {
+        "self": {
+            "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns/c945d6fe-929e-11e3-a2e9-12313d316c29/outreaches/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3"
+        },
+        "osdi:advocacy_campaign": {
+            "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns/c945d6fe-929e-11e3-a2e9-12313d316c29"
+        },
+        "osdi:person": {
+            "href": "https://osdi-sample-system.org/api/v1/people/65345d7d-cd24-466a-a698-4a7686ef684f"
+        }
+    }
+}
+```
+
+_[Back to top...](#)_
+
+
+### Scenario: Creating a new outreach (POST)
+
+Posting to the outreaches collection endpoint and including a link to an existing Person resource will allow you to create a new outreach associated with that advocacy campaign and person. The response is the new outreach that was created. While each implementing system will require different fields, any optional fields not included in a post operation should not be set at all by the receiving system, or should be set to default values.
+
+For information on how to create a person along with an outreach, see the [Record Outreach Helper](record_outreach.html) documentation.
+
+#### Request
+
+```javascript
+POST https://osdi-sample-system.org/api/v1/advocacy_campaigns/c945d6fe-929e-11e3-a2e9-12313d316c29/outreaches/
+
+Header:
+OSDI-API-Token:[your api key here]
+
+{
+    "identifiers": [
+        "foreign_system:1"
+    ],
+    "origin_system": "OpenSupporter",
+    "action_date": "2014-03-18T11:02:15Z",
+    "type": "phone",
+    "duration": 120,
+    "target": {
+        "title": "Senator",
+        "given_name": "John",
+        "family_name": "Smith",
+        "ocdid": "ocd-division/country:us/state:ny"
+    },
+    "_links" : {
+        "osdi:person" : { 
+            "href" : "https://actionnetwork.org/api/v1/people/65345d7d-cd24-466a-a698-4a7686ef684f" 
+        }
+    }
+}
+```
+
+#### Response
+
+```javascript
+200 OK
+
+Content-Type: application/hal+json
+Cache-Control: max-age=0, private, must-revalidate
+
+{
+    "identifiers": [
+        "osdi_sample_system:d91b4b2e-ae0e-4cd3-9ed7-de9uemdse",
+        "foreign_system:1"
+    ],
+    "created_date": "2014-03-20T21:04:31Z",
+    "modified_date": "2014-03-20T21:04:31Z",
+    "action_date": "2014-03-18T11:02:15Z",
+    "type": "phone",
+    "duration": 120,
+    "target": {
+        "title": "Senator",
+        "given_name": "John",
+        "family_name": "Smith",
+        "ocdid": "ocd-division/country:us/state:ny"
+    },
+    "_links": {
+        "self": {
+            "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns/c945d6fe-929e-11e3-a2e9-12313d316c29/outreaches/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse"
+        },
+        "osdi:advocacy_campaign": {
+            "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns/c945d6fe-929e-11e3-a2e9-12313d316c29"
+        },
+        "osdi:person": {
+            "href": "https://actionnetwork.org/api/v1/people/65345d7d-cd24-466a-a698-4a7686ef684f"
+        }
+    }
+}
+```
+
+_[Back to top...](#)_
+
+
+### Scenario: Modifying an outreach (PUT)
+
+You can update an outreach by calling a PUT operation on that outreach's endpoint. Your PUT should contain fields that you want to update. Missing fields will be ignored by the receiving system. Systems may also ignore PUT values, depending on whether fields you are trying to modify are read-only or not. You may set an attribute to nil by including the attribute using `nil` for value.
+
+{% include array_warning.md %}
+
+#### Request
+
+```javascript
+PUT https://osdi-sample-system.org/api/v1/advocacy_campaigns/c945d6fe-929e-11e3-a2e9-12313d316c29/outreaches/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/
+
+Header:
+OSDI-API-Token:[your api key here]
+
+{
+    "action_date": "2014-03-17T11:02:15Z"
+}
+
+```
+
+#### Response
+```javascript
+200 OK
+
+Content-Type: application/hal+json
+Cache-Control: max-age=0, private, must-revalidate
+
+{
+    "identifiers": [
+        "osdi_sample_system:d91b4b2e-ae0e-4cd3-9ed7-de9uemdse",
+        "foreign_system:1"
+    ],
+    "created_date": "2014-03-20T21:04:31Z",
+    "modified_date": "2014-03-20T21:04:31Z",
+    "action_date": "2014-03-17T11:02:15Z",
+    "type": "phone",
+    "duration": 120,
+    "target": {
+        "title": "Senator",
+        "given_name": "John",
+        "family_name": "Smith",
+        "ocdid": "ocd-division/country:us/state:ny"
+    },
+    "_links": {
+        "self": {
+            "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns/c945d6fe-929e-11e3-a2e9-12313d316c29/outreaches/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse"
+        },
+        "osdi:advocacy_campaign": {
+            "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns/c945d6fe-929e-11e3-a2e9-12313d316c29"
+        },
+        "osdi:person": {
+            "href": "https://actionnetwork.org/api/v1/people/65345d7d-cd24-466a-a698-4a7686ef684f"
+        }
+    }
+}
+```
+
+_[Back to top...](#)_
+
+
+### Scenario: Deleting an outreach (DELETE)
+
+You may delete an outreach by calling the DELETE command on the outreach's endpoint.
+
+#### Request
+
+```javascript
+DELETE https://osdi-sample-system.org/api/v1/advocacy_campaigns/c945d6fe-929e-11e3-a2e9-12313d316c29/outreaches/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse
+
+Header:
+OSDI-API-Token:[your api key here]
+```
+
+#### Response
+
+```javascript
+200 OK
+
+Content-Type: application/hal+json
+Cache-Control: max-age=0, private, must-revalidate
+
+{
+    "notice": "This outreach was successfully deleted."
+}
+```
+
+_[Back to top...](#)_

--- a/outreaches.md
+++ b/outreaches.md
@@ -56,7 +56,7 @@ A list of fields specific to the Outreach resource.
 |duration		|integer		|The duration in seconds of the outreach, if applicable. (ex: duration will only be present on phone outreach types)
 |subject		|string		|The subject of the outreach, if applicable. (ex: subject will only be present on email outreach types)
 |message		|string		|The message of the outreach, if applicable. (ex: message will only be present on email or postal mail outreach types)
-|target			|[Target](#target)    |An object hash representing the target of the outreach.
+|targets			|[Target[]](#target)    |An array of target object hashes representing the targets of the outreach.
 
 _[Back to top...](#)_
 
@@ -177,12 +177,20 @@ Cache-Control: max-age=0, private, must-revalidate
                 "type": "email",
                 "subject": "Vote no!",
                 "message": "Please vote no on HR 100.",
-                "target": {
-	                "title": "Senator",
-	                "given_name": "John",
-	                "family_name": "Smith",
-	                "ocdid": "ocd-division/country:us/state:ny"
-	            },
+                "targets": [
+	                {
+	                    "title": "Senator",
+	                    "given_name": "John",
+	                    "family_name": "Smith",
+	                    "ocdid": "ocd-division/country:us/state:ny"
+	                },
+	                {
+	                    "title": "Senator",
+	                    "given_name": "Jennifer",
+	                    "family_name": "Larson",
+	                    "ocdid": "ocd-division/country:us/state:ny"
+	                }
+	            ],
                 "_links": {
                     "self": {
                         "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns/c945d6fe-929e-11e3-a2e9-12313d316c29/outreaches/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3"
@@ -206,11 +214,13 @@ Cache-Control: max-age=0, private, must-revalidate
                 "type": "email",
                 "subject": "Don't do it!",
                 "message": "Vote no tomorrow!",
-                "target": {
-	                "title": "Senator",
-	                "given_name": "Jane",
-	                "family_name": "doe",
-	                "ocdid": "ocd-division/country:us/state:va"
+                "targets": [
+	                {
+	                    "title": "Senator",
+	                    "given_name": "Jane",
+	                    "family_name": "Doe",
+	                    "ocdid": "ocd-division/country:us/state:va"
+	                }
 	            },
                 "_links": {
                     "self": {
@@ -265,12 +275,20 @@ Cache-Control: max-age=0, private, must-revalidate
     "type": "email",
     "subject": "Vote no!",
     "message": "Please vote no on HR 100.",
-    "target": {
-        "title": "Senator",
-        "given_name": "John",
-        "family_name": "Smith",
-        "ocdid": "ocd-division/country:us/state:ny"
-    },
+    "targets": [
+	    {
+	        "title": "Senator",
+	        "given_name": "John",
+	        "family_name": "Smith",
+	        "ocdid": "ocd-division/country:us/state:ny"
+	    },
+	    {
+	        "title": "Senator",
+	        "given_name": "Jennifer",
+	        "family_name": "Larson",
+	        "ocdid": "ocd-division/country:us/state:ny"
+	    }
+	],
     "_links": {
         "self": {
             "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns/c945d6fe-929e-11e3-a2e9-12313d316c29/outreaches/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3"
@@ -310,12 +328,20 @@ OSDI-API-Token:[your api key here]
     "action_date": "2014-03-18T11:02:15Z",
     "type": "phone",
     "duration": 120,
-    "target": {
-        "title": "Senator",
-        "given_name": "John",
-        "family_name": "Smith",
-        "ocdid": "ocd-division/country:us/state:ny"
-    },
+    "targets": [
+	    {
+	        "title": "Senator",
+	        "given_name": "John",
+	        "family_name": "Smith",
+	        "ocdid": "ocd-division/country:us/state:ny"
+	    },
+	    {
+	        "title": "Senator",
+	        "given_name": "Jennifer",
+	        "family_name": "Larson",
+	        "ocdid": "ocd-division/country:us/state:ny"
+	    }
+	],
     "_links" : {
         "osdi:person" : { 
             "href" : "https://actionnetwork.org/api/v1/people/65345d7d-cd24-466a-a698-4a7686ef684f" 
@@ -342,12 +368,20 @@ Cache-Control: max-age=0, private, must-revalidate
     "action_date": "2014-03-18T11:02:15Z",
     "type": "phone",
     "duration": 120,
-    "target": {
-        "title": "Senator",
-        "given_name": "John",
-        "family_name": "Smith",
-        "ocdid": "ocd-division/country:us/state:ny"
-    },
+    "targets": [
+	    {
+	        "title": "Senator",
+	        "given_name": "John",
+	        "family_name": "Smith",
+	        "ocdid": "ocd-division/country:us/state:ny"
+	    },
+	    {
+	        "title": "Senator",
+	        "given_name": "Jennifer",
+	        "family_name": "Larson",
+	        "ocdid": "ocd-division/country:us/state:ny"
+	    }
+	],
     "_links": {
         "self": {
             "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns/c945d6fe-929e-11e3-a2e9-12313d316c29/outreaches/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse"
@@ -402,12 +436,20 @@ Cache-Control: max-age=0, private, must-revalidate
     "action_date": "2014-03-17T11:02:15Z",
     "type": "phone",
     "duration": 120,
-    "target": {
-        "title": "Senator",
-        "given_name": "John",
-        "family_name": "Smith",
-        "ocdid": "ocd-division/country:us/state:ny"
-    },
+    "targets": [
+	    {
+	        "title": "Senator",
+	        "given_name": "John",
+	        "family_name": "Smith",
+	        "ocdid": "ocd-division/country:us/state:ny"
+	    },
+	    {
+	        "title": "Senator",
+	        "given_name": "Jennifer",
+	        "family_name": "Larson",
+	        "ocdid": "ocd-division/country:us/state:ny"
+	    }
+	],
     "_links": {
         "self": {
             "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns/c945d6fe-929e-11e3-a2e9-12313d316c29/outreaches/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse"

--- a/outreaches.md
+++ b/outreaches.md
@@ -7,7 +7,7 @@ title: Outreach
 
 This document defines the Outreach resource. 
 
-Outreachs are a type of action that a user may take by participating in an advocacy campaign. Outreachs have fields to describe them such as when the outreach was created, who the user contacted as the target of their advocacy, and the content of the message a user sent to that target, and typically are linked to the person who made the outreach.
+Outreachs are a type of action that a user may take by participating in an [advocacy campaign](advocacy_campaigns.html). Outreaches have fields to describe them such as when the outreach was created, who the user contacted as the target of their advocacy, and the content of the message a user sent to that target, and typically are linked to the person who made the outreach.
 
 
 ### Sections
@@ -24,8 +24,8 @@ Outreachs are a type of action that a user may take by participating in an advoc
     * [Scenario: Retrieving a collection of Outreach resources (GET)](#scenario-retrieving-a-collection-of-outreach-resources-get)
     * [Scenario: Retrieving an individual Outreach resource (GET)](#scenario-scenario-retrieving-an-individual-outreach-resource-get)
     * [Scenario: Creating a new outreach (POST)](#scenario-creating-a-new-outreach-post)
-    * [Scenario: Modifying a outreach (PUT)](#scenario-modifying-a-outreach-put)
-    * [Scenario: Deleting a outreach (DELETE)](#scenario-deleting-a-outreach-delete)
+    * [Scenario: Modifying an outreach (PUT)](#scenario-modifying-an-outreach-put)
+    * [Scenario: Deleting an outreach (DELETE)](#scenario-deleting-an-outreach-delete)
 
 
 {% include endpoints_and_url_structures.md %}
@@ -44,7 +44,7 @@ _[Back to top...](#)_
 _[Back to top...](#)_
 
 
-### Signature Fields
+### Outreach Fields
 
 A list of fields specific to the Outreach resource.
 

--- a/people.md
+++ b/people.md
@@ -176,6 +176,7 @@ _[Back to top...](#)_
 |submissions	|[Submissions[]*](submissions.html)  |A link to the collection of form submissions associated with the person.
 |attendances		|[Attendances[]*](attendances.html)        |A link to the collection of event attendances associated with the person.
 |signatures		|[Signatures[]*](signatures.html)        |A link to the collection of petition signatures associated with the person.
+|outreaches		|[Outreaches[]*](outreaches.html)        |A link to the collection of advocacy campaign outreaches associated with the person.
 |answers		|[Answers[]*](answers.html)  |A link to the collection of answers to questions associated with the person.
 |taggings		|[Taggings[]*](taggings.html)   	|A link to the collection of taggings associated with the person.
 |items		|[Items[]*](items.html)   	|A link to the collection of list items associated with the person.
@@ -391,6 +392,9 @@ Cache-Control: max-age=0, private, must-revalidate
                     "osdi:donations": {
                         "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/donations"
                     },
+                    "osdi:outreaches": {
+                        "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/outreaches"
+                    },
                     "osdi:taggings": {
                         "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/taggings"
                     },
@@ -448,6 +452,9 @@ Cache-Control: max-age=0, private, must-revalidate
                     },
                     "osdi:donations": {
                         "href": "https://osdi-sample-system.org/api/v1/people/1efc3644-af25-4253-90b8-a0baf12dbd1e/donations"
+                    },
+                    "osdi:outreaches": {
+                        "href": "https://osdi-sample-system.org/api/v1/people/1efc3644-af25-4253-90b8-a0baf12dbd1e/outreaches"
                     },
                     "osdi:taggings": {
                         "href": "https://osdi-sample-system.org/api/v1/people/1efc3644-af25-4253-90b8-a0baf12dbd1e/taggings"
@@ -612,6 +619,9 @@ Cache-Control: max-age=0, private, must-revalidate
         "osdi:donations": {
             "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/donations"
         },
+        "osdi:outreaches": {
+            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/outreaches"
+        },
         "osdi:taggings": {
             "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/taggings"
         },
@@ -750,6 +760,9 @@ Cache-Control: max-age=0, private, must-revalidate
         "osdi:donations": {
             "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/donations"
         },
+        "osdi:outreaches": {
+            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/outreaches"
+        },
         "osdi:taggings": {
             "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/taggings"
         },
@@ -857,6 +870,9 @@ Cache-Control: max-age=0, private, must-revalidate
         },
         "osdi:donations": {
             "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/donations"
+        },
+        "osdi:outreaches": {
+            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/outreaches"
         },
         "osdi:taggings": {
             "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/taggings"

--- a/person_signup.md
+++ b/person_signup.md
@@ -209,6 +209,9 @@ Cache-Control: max-age=0, private, must-revalidate
         "osdi:donations": {
             "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/donations"
         },
+        "osdi:outreaches": {
+            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/outreaches"
+        },
         "osdi:taggings": {
             "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/taggings"
         },

--- a/record_donation.md
+++ b/record_donation.md
@@ -240,10 +240,10 @@ Cache-Control: max-age=0, private, must-revalidate
     ],
     "_links": {
         "self": {
-            "href": "https://osdi-sample-system.org/api/v1/petitions/c945d6fe-929e-11e3-a2e9-12313d316c29/signature/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse"
+            "href": "https://osdi-sample-system.org/api/v1/fundraising_pages/c945d6fe-929e-11e3-a2e9-12313d316c29/doantions/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse"
         },
-        "osdi:petition": {
-            "href": "https://osdi-sample-system.org/api/v1/petitions/c945d6fe-929e-11e3-a2e9-12313d316c29"
+        "osdi:fundraising_page": {
+            "href": "https://osdi-sample-system.org/api/v1/fundraising_pages/c945d6fe-929e-11e3-a2e9-12313d316c29"
         },
         "osdi:person": {
             "href": "https://osdi-sample-system.org/api/v1/people/adb951cb-51f9-420e-b7e6-de953195ec86"

--- a/record_outreach.md
+++ b/record_outreach.md
@@ -1,0 +1,207 @@
+---
+layout: default
+title: Record Outreach Helper
+---
+
+# Record Outreach Helper
+
+This document defines the Record Outreach Helper resource. 
+
+The Record Outreach Helper is a helper endpoint to aid in the creation of [Outreach](outreaches.html) and [People](people.html) resources via POST. It provides a quick and easy way to create outreaches and people at the same time, eliminating the need for multiple POST operations to store that information.
+
+Some systems may attempt to match people sent via the Record Outreach Helper to existing people in the database and update their record instead of creating a new person. The method used for matching will be detailed in that system's documentation. 
+
+The response to a Record Outreach Helper POST is the full representation of the outreach.
+
+Some initial implementations may only support helpers -- direct RESTful access may not be supported. In those cases, the _links section may be omitted in responses.
+
+
+### Sections:
+
+* [Endpoints and URL structures](#endpoints-and-url-structures)
+* [Fields](#fields)
+	* [Common Fields](#common-fields)
+    * [Record Outreach Helper Fields](#record-outreach-helper-fields)
+    * [Related Objects](#related-objects)
+* [Related Resources](#related-resources)
+* [Scenarios](#scenarios)
+    * [Scenario: Creating a new outreach and person (POST)](#scenario-creating-a-new-outreach-and-person-post)
+
+
+{% include endpoints_and_url_structures.md %}
+
+The link relation label for the Record Outreach Helper is ```osdi:record_outreach_helper```.
+
+_[Back to top...](#)_
+
+
+## Fields
+
+{% include fields_intro.md %}
+
+{% include global_fields_helper.md %}
+
+_[Back to top...](#)_
+
+
+### Record Outreach Helper Fields
+
+A list of fields specific for POSTing via the Record Outreach Helper.
+
+| Name          | Type      | Description
+|-----------    |-----------|-----------|--------------
+|origin_system		|string     |A human readable identifier of the system where this outreach was created. (ex: "OSDI System")
+|action_date		|string		|The date and time the outreach was made by the person.
+|type				|flexunum	|The type of outreach, specifying how the user performed the outreach to targets. One of "email", "in-person", "phone", "postal mail", or another type as needed.
+|duration		|integer		|The duration in seconds of the outreach, if applicable. (ex: duration will only be present on phone outreach types)
+|subject		|string		|The subject of the outreach, if applicable. (ex: subject will only be present on email outreach types)
+|message		|string		|The message of the outreach, if applicable. (ex: message will only be present on email or postal mail outreach types)
+|target			|[Target](#target)    |An object hash representing the target of the outreach.
+|person			|[Person*](#person)	|An object hash representing the person who made the outreach.
+
+_[Back to top...](#)_
+
+
+### Related Objects
+
+These JSON hashes included in the table above are broken out into their own tables for readability, rather than independent resources with their own endpoints.
+
+#### Target
+
+|Name          	|Type      |Description
+|-----------    |-----------|--------------
+|target.title	|string    |The title of the target. (ex: "Senator")
+|target.given_name	|string    |The first or given name of the target. (ex: "John")
+|target.family_name	|string    |The last or family name of the target. (ex: "Smith")
+|target.ocdid	|string    |The Open Civic Data Division ID for this target's political geography, if applicable. See [here](http://docs.opencivicdata.org/en/latest/proposals/0002.html) for more documentation. (ex: "ocd-division/country:us/state:ny/cd:18", which corresponds to New York's 18th Congressional District)
+
+#### Person
+
+|Name          |Type      |Description
+|-----------    |-----------|--------------
+|person      |[Person*](people.html)     |An inlined hash representation of a person, containing any valid fields for the Person resource.
+
+_[Back to top...](#)_
+
+
+## Related Resources
+
+* [Outreach](outreaches.html)
+* [Person](people.html)
+
+_[Back to top...](#)_
+
+
+## Scenarios
+
+{% include scenarios_helper_intro.md %}
+
+
+### Scenario: Creating a new outreach and person (POST)
+
+Posting to the record outreach helper endpoint will allow you to create a new outreach and person (or update a person if the system attempts to match people posted with helpers) in one operation. The response is the outreach that was created. While each implementing system will require different fields, any optional fields not included in a post operation should not be set at all by the receiving system, or should be set to default values.
+
+#### Request
+
+```javascript
+POST https://osdi-sample-system.org/api/v1/advocacy_campaigns/c945d6fe-929e-11e3-a2e9-12313d316c29/record_outreach_helper
+
+Header:
+OSDI-API-Token:[your api key here]
+
+{
+    "person": {
+        "identifiers": [
+            "foreign_system:1"
+        ],
+        "family_name": "Edwin",
+        "given_name": "Labadie",
+        "additional_name": "Marques",
+        "origin_system": "OpenSupporter",
+        "email_addresses": [
+            {
+                "address":"test-3@example.com",
+                "primary": true,
+                "address_type": "Personal"
+            }
+        ],
+        "postal_addresses": [
+            {
+                "primary": true,
+                "address_lines": [
+                    "935 Ed Lock"
+                ],
+                "locality": "New Dudley",
+                "region": "MN",
+                "postal_code": "17678",
+                "country": "RU",
+                "address_type": "Home",
+                "status": "Verified"
+            }
+        ],
+        "phone_numbers": [
+            {
+                "primary": true,
+                "number": 19876543210,
+                "number_type": "Mobile",
+                "sms_capable": true
+            }
+        ],
+        "gender": "Male"
+    },
+    "identifiers": [
+        "foreign_system:1"
+    ],
+    "origin_system": "OpenSupporter",
+    "action_date": "2014-03-18T11:02:15Z",
+    "type": "phone",
+    "duration": 120,
+    "target": {
+        "title": "Senator",
+        "given_name": "John",
+        "family_name": "Smith",
+        "ocdid": "ocd-division/country:us/state:ny"
+    }
+}
+```
+
+#### Response
+
+```javascript
+200 OK
+
+Content-Type: application/hal+json
+Cache-Control: max-age=0, private, must-revalidate
+
+{
+    "identifiers": [
+        "osdi_sample_system:d91b4b2e-ae0e-4cd3-9ed7-de9uemdse",
+        "foreign_system:1"
+    ],
+    "created_date": "2014-03-20T21:04:31Z",
+    "modified_date": "2014-03-20T21:04:31Z",
+    "action_date": "2014-03-18T11:02:15Z",
+    "origin_system": "OpenSupporter",
+    "type": "phone",
+    "duration": 120,
+    "target": {
+        "title": "Senator",
+        "given_name": "John",
+        "family_name": "Smith",
+        "ocdid": "ocd-division/country:us/state:ny"
+    },
+    "_links": {
+        "self": {
+            "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns/c945d6fe-929e-11e3-a2e9-12313d316c29/outreaches/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse"
+        },
+        "osdi:advocacy_campaign": {
+            "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns/c945d6fe-929e-11e3-a2e9-12313d316c29"
+        },
+        "osdi:person": {
+            "href": "https://osdi-sample-system.org/api/v1/people/adb951cb-51f9-420e-b7e6-de953195ec86"
+        }
+    }
+}
+```
+
+_[Back to top...](#)_

--- a/record_outreach.md
+++ b/record_outreach.md
@@ -56,7 +56,7 @@ A list of fields specific for POSTing via the Record Outreach Helper.
 |duration		|integer		|The duration in seconds of the outreach, if applicable. (ex: duration will only be present on phone outreach types)
 |subject		|string		|The subject of the outreach, if applicable. (ex: subject will only be present on email outreach types)
 |message		|string		|The message of the outreach, if applicable. (ex: message will only be present on email or postal mail outreach types)
-|target			|[Target](#target)    |An object hash representing the target of the outreach.
+|targets			|[Target[]](#target)    |A array of target object hashes representing the targets of the outreach.
 |person			|[Person*](#person)	|An object hash representing the person who made the outreach.
 
 _[Back to top...](#)_
@@ -70,7 +70,8 @@ These JSON hashes included in the table above are broken out into their own tabl
 
 |Name          	|Type      |Description
 |-----------    |-----------|--------------
-|target.title	|string    |The title of the target. (ex: "Senator")
+|target.title	|string    |The title or position of the target. (ex: "Senator" or "CEO")
+|target.organization	|string	|The organization the target belongs to. (ex: "U.S. Senate" or "Acme Corporation")
 |target.given_name	|string    |The first or given name of the target. (ex: "John")
 |target.family_name	|string    |The last or family name of the target. (ex: "Smith")
 |target.ocdid	|string    |The Open Civic Data Division ID for this target's political geography, if applicable. See [here](http://docs.opencivicdata.org/en/latest/proposals/0002.html) for more documentation. (ex: "ocd-division/country:us/state:ny/cd:18", which corresponds to New York's 18th Congressional District)
@@ -156,12 +157,22 @@ OSDI-API-Token:[your api key here]
     "action_date": "2014-03-18T11:02:15Z",
     "type": "phone",
     "duration": 120,
-    "target": {
-        "title": "Senator",
-        "given_name": "John",
-        "family_name": "Smith",
-        "ocdid": "ocd-division/country:us/state:ny"
-    }
+    "targets": [
+	    {
+	        "title": "Senator",
+	        "given_name": "John",
+	        "family_name": "Smith",
+	        "organization": "U.S. Senate",
+	        "ocdid": "ocd-division/country:us/state:ny"
+	    },
+	    {
+	        "title": "Senator",
+	        "given_name": "Jennifer",
+	        "family_name": "Larson",
+	        "organization": "U.S. Senate",
+	        "ocdid": "ocd-division/country:us/state:ny"
+	    }
+	]
 }
 ```
 
@@ -184,12 +195,22 @@ Cache-Control: max-age=0, private, must-revalidate
     "origin_system": "OpenSupporter",
     "type": "phone",
     "duration": 120,
-    "target": {
-        "title": "Senator",
-        "given_name": "John",
-        "family_name": "Smith",
-        "ocdid": "ocd-division/country:us/state:ny"
-    },
+    "targets": [
+	    {
+	        "title": "Senator",
+	        "given_name": "John",
+	        "family_name": "Smith",
+	        "organization": "U.S. Senate",
+	        "ocdid": "ocd-division/country:us/state:ny"
+	    },
+	    {
+	        "title": "Senator",
+	        "given_name": "Jennifer",
+	        "family_name": "Larson",
+	        "organization": "U.S. Senate",
+	        "ocdid": "ocd-division/country:us/state:ny"
+	    }
+	],
     "_links": {
         "self": {
             "href": "https://osdi-sample-system.org/api/v1/advocacy_campaigns/c945d6fe-929e-11e3-a2e9-12313d316c29/outreaches/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse"

--- a/record_signature.md
+++ b/record_signature.md
@@ -165,7 +165,7 @@ Cache-Control: max-age=0, private, must-revalidate
     "comments": "Support our campaign!",
     "_links": {
         "self": {
-            "href": "https://osdi-sample-system.org/api/v1/petitions/c945d6fe-929e-11e3-a2e9-12313d316c29/signature/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse"
+            "href": "https://osdi-sample-system.org/api/v1/petitions/c945d6fe-929e-11e3-a2e9-12313d316c29/signatures/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse"
         },
         "osdi:petition": {
             "href": "https://osdi-sample-system.org/api/v1/petitions/c945d6fe-929e-11e3-a2e9-12313d316c29"

--- a/signatures.md
+++ b/signatures.md
@@ -365,7 +365,7 @@ You may delete a signature by calling the DELETE command on the signature's endp
 #### Request
 
 ```javascript
-DELETE https://osdi-sample-system.org/api/v1/petitions/c945d6fe-929e-11e3-a2e9-12313d316c29/signature/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse
+DELETE https://osdi-sample-system.org/api/v1/petitions/c945d6fe-929e-11e3-a2e9-12313d316c29/signatures/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse
 
 Header:
 OSDI-API-Token:[your api key here]


### PR DESCRIPTION
Here's my first draft of an advocacy proposal, including the Advocacy Campaign resource representing the umbrella campaign object, the Outreach resource representing each individual outreach made to advocacy targets by people, and the Record Outreach Helper to help POST an outreach and a person at the same time.

A few notes and points for discussion:

* I don't love the names that I've chosen here, Advocacy Campaign and Outreach. Outreach especially is awkward -- the plural is "Outreaches" -- though I guess not more awkward than Taggings. Anyway, if folks have thoughts on other names, happy to hear them.
* I've put a type field on the Advocacy Campaign resource as a kind of hint to the type of Outreaches you can expect for this campaign (ie: phone, or email, or in-person). This means that Advocacy Campaigns then can only contain one type of Outreach. I'm not sure I've seen a system that can handle more than one type in a single campaign, but maybe I'm wrong there. Type could easily be removed and just be present on individual Outreaches.
* Targets are not their own resources. I can see them becoming such in the future, but for now it seemed like overkill.
* I'm using OCDID as an identifier for targets. I know it's not a standard everyone uses, but it is in fact a standard, and I'm not sure there's really another one to use instead. Of course, like everything, it's optional, so if you don't use it, just don't have the field, but it seems useful for matching and analysis, especially because targets are not their own resources.

All other comments welcome!