### PR TITLE
Changed 'Citizen Action NY'

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ _[Back to top...](#)_
 * Marc Love, Independent
 * Walter Ludwig, Indigo Strategies
 * Drew Miller, NGP VAN
-* Joe McLaughlin, Citizen Action NY
+* Joe McLaughlin, Citizen Action of New York
 * Mark Paquette, TheDataBank
 * Charles Parsons, Salsa Labs
 * Rich Ranallo, Revolution Messaging


### PR DESCRIPTION
Changed 'Citizen Action NY' to 'Citizen Action of New York' in 399