### PR TITLE
Make record canvass helper discoverable

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Experiment with our prototype server: [http://api.opensupporter.org](http://api.
 OSDI used a combination of approaches to provide flexible reading of data, simple operations for simple scenarios, and general purpose CRUD access.
 
 ### Version
-This document represents OSDI version 1.0.1
+This document represents OSDI version 1.0.3
 
 ### Working with OSDI in Real Life
 

--- a/people.md
+++ b/people.md
@@ -181,6 +181,7 @@ _[Back to top...](#)_
 |taggings		|[Taggings[]*](taggings.html)   	|A link to the collection of taggings associated with the person.
 |items		|[Items[]*](items.html)   	|A link to the collection of list items associated with the person.
 |modified_by		|[Person*](people.html)  	|A link to a Person resource representing the last editor of this person.
+|record_canvas |[Record Canvass Helper*](record_canvass.html) | A link to the Record Canvass Helper for this person.
 
 _[Back to top...](#)_
 
@@ -400,6 +401,9 @@ Cache-Control: max-age=0, private, must-revalidate
                     },
                     "osdi:items": {
                         "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/items"
+                    },
+                    "osdi:record_canvass": {
+                        "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/record_canvass_helper"
                     }
                 }
             },
@@ -461,6 +465,9 @@ Cache-Control: max-age=0, private, must-revalidate
                     },
                     "osdi:items": {
                         "href": "https://osdi-sample-system.org/api/v1/people/1efc3644-af25-4253-90b8-a0baf12dbd1e/items"
+                    },
+                    "osdi:record_canvass": {
+                        "href": "https://osdi-sample-system.org/api/v1/people/1efc3644-af25-4253-90b8-a0baf12dbd1e/record_canvass_helper"
                     }
                 }
             },
@@ -627,6 +634,9 @@ Cache-Control: max-age=0, private, must-revalidate
         },
         "osdi:items": {
             "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/items"
+        },
+        "osdi:record_canvass": {
+            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/record_canvass_helper"
         }
     }
 }
@@ -768,6 +778,9 @@ Cache-Control: max-age=0, private, must-revalidate
         },
         "osdi:items": {
             "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/items"
+        },
+        "osdi:record_canvass": {
+            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/record_canvass_helper"
         }
     }
 }
@@ -879,6 +892,9 @@ Cache-Control: max-age=0, private, must-revalidate
         },
         "osdi:items": {
             "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/items"
+        },
+        "osdi:record_canvass": {
+            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/record_canvass_helper"
         }
     }
 }

--- a/people.md
+++ b/people.md
@@ -181,7 +181,7 @@ _[Back to top...](#)_
 |taggings		|[Taggings[]*](taggings.html)   	|A link to the collection of taggings associated with the person.
 |items		|[Items[]*](items.html)   	|A link to the collection of list items associated with the person.
 |modified_by		|[Person*](people.html)  	|A link to a Person resource representing the last editor of this person.
-|record_canvas |[Record Canvass Helper*](record_canvass.html) | A link to the Record Canvass Helper for this person.
+|record_canvas_helper |[Record Canvass Helper*](record_canvass.html) | A link to the Record Canvass Helper for this person.
 
 _[Back to top...](#)_
 
@@ -402,7 +402,7 @@ Cache-Control: max-age=0, private, must-revalidate
                     "osdi:items": {
                         "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/items"
                     },
-                    "osdi:record_canvass": {
+                    "osdi:record_canvass_helper": {
                         "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/record_canvass_helper"
                     }
                 }
@@ -466,7 +466,7 @@ Cache-Control: max-age=0, private, must-revalidate
                     "osdi:items": {
                         "href": "https://osdi-sample-system.org/api/v1/people/1efc3644-af25-4253-90b8-a0baf12dbd1e/items"
                     },
-                    "osdi:record_canvass": {
+                    "osdi:record_canvass_helper": {
                         "href": "https://osdi-sample-system.org/api/v1/people/1efc3644-af25-4253-90b8-a0baf12dbd1e/record_canvass_helper"
                     }
                 }
@@ -635,7 +635,7 @@ Cache-Control: max-age=0, private, must-revalidate
         "osdi:items": {
             "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/items"
         },
-        "osdi:record_canvass": {
+        "osdi:record_canvass_helper": {
             "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/record_canvass_helper"
         }
     }
@@ -779,7 +779,7 @@ Cache-Control: max-age=0, private, must-revalidate
         "osdi:items": {
             "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/items"
         },
-        "osdi:record_canvass": {
+        "osdi:record_canvass_helper": {
             "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/record_canvass_helper"
         }
     }
@@ -893,7 +893,7 @@ Cache-Control: max-age=0, private, must-revalidate
         "osdi:items": {
             "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/items"
         },
-        "osdi:record_canvass": {
+        "osdi:record_canvass_helper": {
             "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/record_canvass_helper"
         }
     }


### PR DESCRIPTION
Turns out there was no way to discover the record canvass helper!  This PR fixes that.  Assuming we are good with this approach, we probably want to do the same for record attendance helper, record donation helper, etc., but I wanted to start with this so I can get our Record Canvass Helper implementation going.