### PR TITLE
helpers with URIs and AEP namespace attr

### DIFF
--- a/aep.md
+++ b/aep.md
@@ -40,6 +40,7 @@ A list of fields specific to the AEP resource.
 |vendor_name    | string    | A string representing the vendor name
 |product_name   | string    | A string identifying the product name
 |osdi_version	| string	| A string identifying the OSDI Version
+|namespace      | string    | A string representing the prefix used for curies, identifiers, and other applicable places.
 
 _[Back to top...](#)_
 
@@ -115,6 +116,7 @@ Cache-Control: max-age=0, private, must-revalidate
     "product_name" : "Curly Braces OSDI Server",
 	"osdi_version" : "1.0",
     "max_pagesize": 25,
+    "namespace": "osdi_sample_system",
     "_links": {
         "curies": [
             {

--- a/person_signup.md
+++ b/person_signup.md
@@ -135,8 +135,8 @@ OSDI-API-Token:[your api key here]
         "volunteer",
         "donor"
     ],
-    "add_lists": [
-        "supporters"
+    "add_lists_uri": [
+        "https://osdi-sample-system.org/api/v1/lists/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3"
     ]
 }
 ```

--- a/person_signup.md
+++ b/person_signup.md
@@ -48,6 +48,7 @@ A list of fields specific for POSTing via the Person Signup Helper.
 |Name          |Type      |Description
 |-----------    |-----------|--------------
 |add_tags      |strings[]     |An array of tag names corresponding to previously created tags to add to this person when it is created.
+|add_tags_uri  |strings[]     |An array of tag URIs corresponding to previously created tags to add to this person when it is created.
 |add_lists     |strings[]     |An array of list names corresponding to previously created lists to add to this person when it is created.
 |person			|[Person*](#person)	|An object hash representing the person to be added.
 
@@ -134,6 +135,9 @@ OSDI-API-Token:[your api key here]
     "add_tags": [
         "volunteer",
         "donor"
+    ],
+    "add_tags_uri": [
+        "https://osdi-sample-system.org/api/v1/tags/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3"
     ],
     "add_lists_uri": [
         "https://osdi-sample-system.org/api/v1/lists/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3"


### PR DESCRIPTION
Updated proposal based on 8/27 tech meeting.
Use URIs for helper functions (add_lists) but not tags
add AEP attr for namespace prefix