### PR TITLE
Sources and referrers proposal

### DIFF
--- a/_includes/helper_action_functions.md
+++ b/_includes/helper_action_functions.md
@@ -10,7 +10,7 @@ Helper Action Functions are additional actions that the OSDI server will perform
 |add_questions_responses_uri      |[QuestionResponseObject](#question-response-object-fields)     |An array of Question Response Objects, indicating answers which should be applied to the person.
 |triggers		|[Triggers](#triggers)	|An object hash representing responses a user would like to trigger from the server as part of the POST, such as sending an autoresponse email back to the person who took action with this helper.
 
-### Question Response Object Fields
+#### Question Response Object Fields
 
 |Name          |Type      |Description
 |-----------    |-----------|--------------

--- a/attendances.md
+++ b/attendances.md
@@ -139,7 +139,7 @@ _[Back to top...](#)_
 
 Attendance resources are sometimes presented as collections of attendances. For example, calling the attendance endpoint on a particular event will return a collection of all the attendances made to that event.
 
-Ticketed event attendances and non-ticketed event attendances look different. First, an example of non-ticketed event attendaces:
+Ticketed event attendances and non-ticketed event attendances look different. First, an example of non-ticketed event attendances:
 
 #### Request
 

--- a/attendances.md
+++ b/attendances.md
@@ -57,6 +57,7 @@ A list of fields specific to the Attendance resource.
 |status			|flexenum			|The attendee's response status. One of "declined", "tentative", "accepted", "cancelled", or "needs action".  Note: OSDI vendors may implement varying or client-configured statuses; users should check with the vendor for available attendance status values. 
 |attended		|boolean		|For event RSVPs, represents whether the person actually attended the event or not. For ticketed events, field should be absent, as it's superseded by the `attended` field in the `ticket` object.
 |comment		|string			|An optional comment from the attendee.
+|referrer_data		|[Referrer Data*](#referrer-data)	|An object hash representing referrer and sourcing information about this attendance.
 |tickets		|[Tickets[]](#tickets)	|If this event is a ticketed event, an array of object hashes representing each ticket purchased as part of this attendance. (ex: One $5 general admission ticket for Sam and two $50 VIP tickets for Sally and Saul.)
 
 
@@ -66,6 +67,15 @@ _[Back to top...](#)_
 ### Related Objects
 
 These JSON hashes included in the table above are broken out into their own tables for readability, rather than independent resources with their own endpoints.
+
+#### Referrer Data
+
+|Name          |Type      |Description
+|-----------    |-----------|--------------
+|referrer_data.source	|string    |The source code that was used when this attendance was created. Typically used to track individual links, such as a post on social media or a link in a specific email. (ex: "facebook-101016-mainpage")
+|referrer_data.referrer	|string    |The code representing a person or group that referred this attendance. Typically used to track which person referred the person who made this attendance to attend. (ex: "jane-doe")
+|referrer_data.website	|string    |The URL of the website where the person clicked from to then subsequently make this attendance. (ex: "https://facebook.com")
+
 
 #### Tickets
 
@@ -191,6 +201,11 @@ Cache-Control: max-age=0, private, must-revalidate
                 "status": "confirmed",
                 "attended": true,
                 "comment": "Looking forward to it!",
+                "referrer_data": {
+                    "source": "facebook-101016-mainpage",
+                    "referrer": "jane-doe",
+                    "website": "https://facebook.com"
+                },
                 "_links": {
                     "self": {
                         "href": "https://osdi-sample-system.org/api/v1/events/c945d6fe-929e-11e3-a2e9-12313d316c29/attendances/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3"
@@ -216,6 +231,9 @@ Cache-Control: max-age=0, private, must-revalidate
                 "action_date": "2014-03-12T01:45:34Z",
                 "status": "tentative",
                 "attended": false,
+                "referrer_data": {
+                    "source": "email-101116-subjecttest1"
+                },
                 "_links": {
                     "self": {
                         "href": "https://osdi-sample-system.org/api/v1/events/c945d6fe-929e-11e3-a2e9-12313d316c29/attendances/1efc3644-af25-4253-90b8-a0baf12dbd1e"
@@ -295,6 +313,10 @@ Cache-Control: max-age=0, private, must-revalidate
                 "action_date": "2014-03-18T11:02:15Z",
                 "status": "confirmed",
                 "comment": "Looking forward to it!",
+                "referrer_data": {
+                    "source": "twitter-101016",
+                    "website": "https://twitter.com"
+                },
                 "tickets": [
                     {
                         "title": "General Admission",
@@ -357,6 +379,9 @@ Cache-Control: max-age=0, private, must-revalidate
                 "modified_date": "2014-03-20T20:44:13Z",
                 "action_date": "2014-03-12T01:45:34Z",
                 "status": "tentative",
+                "referrer_data": {
+                    "source": "email-101216-final"
+                },
                 "tickets": [
                     {
                         "title": "General Admission",
@@ -432,6 +457,11 @@ Cache-Control: max-age=0, private, must-revalidate
     "status": "confirmed",
     "attended": true,
     "comment": "Looking forward to it!",
+    "referrer_data": {
+        "source": "facebook-101016-mainpage",
+        "referrer": "jane-doe",
+        "website": "facebook.com"
+    },
     "_links": {
         "self": {
             "href": "https://osdi-sample-system.org/api/v1/events/c945d6fe-929e-11e3-a2e9-12313d316c29/attendances/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3"
@@ -480,6 +510,11 @@ Cache-Control: max-age=0, private, must-revalidate
     "action_date": "2014-03-18T11:02:15Z",
     "status": "confirmed",
     "comment": "Looking forward to it!",
+    "referrer_data": {
+        "source": "facebook-101016-mainpage",
+        "referrer": "jane-doe",
+        "website": "facebook.com"
+    },
     "tickets": [
         {
             "title": "General Admission",
@@ -560,6 +595,9 @@ OSDI-API-Token:[your api key here]
     ],
     "origin_system": "OpenSupporter",
     "action_date": "2014-03-18T11:02:15Z",
+    "referrer_data": {
+        "source": "api"
+    },
     "_links" : {
         "osdi:person" : { 
             "href" : "https://actionnetwork.org/api/v1/people/65345d7d-cd24-466a-a698-4a7686ef684f" 
@@ -584,6 +622,9 @@ Cache-Control: max-age=0, private, must-revalidate
     "created_date": "2014-03-20T21:04:31Z",
     "modified_date": "2014-03-20T21:04:31Z",
     "action_date": "2014-03-18T11:02:15Z",
+    "referrer_data": {
+        "source": "api"
+    },
     "_links": {
         "self": {
             "href": "https://osdi-sample-system.org/api/v1/events/c945d6fe-929e-11e3-a2e9-12313d316c29/attendances/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse"
@@ -614,6 +655,9 @@ OSDI-API-Token:[your api key here]
     ],
     "origin_system": "OpenSupporter",
     "action_date": "2014-03-18T11:02:15Z",
+    "referrer_data": {
+        "source": "api"
+    },
     "tickets": [
         {
             "title": "General Admission",
@@ -676,6 +720,9 @@ Cache-Control: max-age=0, private, must-revalidate
     "created_date": "2014-03-20T21:04:31Z",
     "modified_date": "2014-03-20T21:04:31Z",
     "action_date": "2014-03-18T11:02:15Z",
+    "referrer_data": {
+        "source": "api"
+    },
     "tickets": [
         {
             "title": "General Admission",
@@ -768,6 +815,11 @@ Cache-Control: max-age=0, private, must-revalidate
     "modified_date": "2014-03-20T22:04:31Z",
     "action_date": "2014-03-17T11:02:15Z",
     "status": "declined",
+    "referrer_data": {
+        "source": "facebook-101016-mainpage",
+        "referrer": "jane-doe",
+        "website": "facebook.com"
+    },
     "_links": {
         "self": {
             "href": "https://osdi-sample-system.org/api/v1/events/c945d6fe-929e-11e3-a2e9-12313d316c29/attendances/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse"

--- a/attendances.md
+++ b/attendances.md
@@ -73,8 +73,9 @@ These JSON hashes included in the table above are broken out into their own tabl
 |Name          |Type      |Description
 |-----------    |-----------|--------------
 |referrer_data.source	|string    |The source code that was used when this attendance was created. Typically used to track individual links, such as a post on social media or a link in a specific email. (ex: "facebook-101016-mainpage")
-|referrer_data.referrer	|string    |The code representing a person or group that referred this attendance. Typically used to track which person referred the person who made this attendance to attend. (ex: "jane-doe")
-|referrer_data.website	|string    |The URL of the website where the person clicked from to then subsequently make this attendance. (ex: "https://facebook.com")
+|referrer_data.referrer	|string    |The code or ID representing a person or group that referred this attendance. Typically used to track which person referred the person who made this attendance. (ex: "jane-doe")
+|referrer_data.website	|string    |The top level domain of the website where the person clicked from to then subsequently make this attendance. (ex: "facebook.com")
+|referrer_data.url	|string    |The specific URL where the person clicked from to then subsequently make this attendance. (ex: "https://facebook.com/posts/12345")
 
 
 #### Tickets
@@ -204,7 +205,8 @@ Cache-Control: max-age=0, private, must-revalidate
                 "referrer_data": {
                     "source": "facebook-101016-mainpage",
                     "referrer": "jane-doe",
-                    "website": "https://facebook.com"
+                    "website": "facebook.com",
+                    "url": "https://facebook.com/posts/12345"
                 },
                 "_links": {
                     "self": {
@@ -315,7 +317,7 @@ Cache-Control: max-age=0, private, must-revalidate
                 "comment": "Looking forward to it!",
                 "referrer_data": {
                     "source": "twitter-101016",
-                    "website": "https://twitter.com"
+                    "website": "twitter.com"
                 },
                 "tickets": [
                     {
@@ -460,7 +462,8 @@ Cache-Control: max-age=0, private, must-revalidate
     "referrer_data": {
         "source": "facebook-101016-mainpage",
         "referrer": "jane-doe",
-        "website": "facebook.com"
+        "website": "facebook.com",
+        "url": "https://facebook.com/posts/12345"
     },
     "_links": {
         "self": {
@@ -513,7 +516,8 @@ Cache-Control: max-age=0, private, must-revalidate
     "referrer_data": {
         "source": "facebook-101016-mainpage",
         "referrer": "jane-doe",
-        "website": "facebook.com"
+        "website": "facebook.com",
+        "url": "https://facebook.com/posts/12345"
     },
     "tickets": [
         {
@@ -818,7 +822,8 @@ Cache-Control: max-age=0, private, must-revalidate
     "referrer_data": {
         "source": "facebook-101016-mainpage",
         "referrer": "jane-doe",
-        "website": "facebook.com"
+        "website": "facebook.com",
+        "url": "https://facebook.com/posts/12345"
     },
     "_links": {
         "self": {

--- a/donations.md
+++ b/donations.md
@@ -15,6 +15,7 @@ Donations are a type of action that a user may take by donating on a fundraising
 * [Fields](#fields)
     * [Common Fields](#common-fields)
     * [Donation Fields](#donation-fields)  
+    * [Related Objects](#related-objects)
     * [Links](#links)
 * [Helpers](#helpers)
 * [Related Resources](#related-resources)
@@ -57,6 +58,10 @@ _[Back to top...](#)_
 |voided			|boolean	|Indicates if the donation has been voided.
 |voided_date  	|datetime		|Date of the void.
 |url			|string		|URL at which the donation was taken.
+|referrer_data		|[Referrer Data*](#referrer-data)	|An object hash representing referrer and sourcing information about this donation.
+
+_[Back to top...](#)_
+
 
 ## Related Objects
 These JSON hashes included in the table above are broken out into their own tables for readability, rather than independent resources with their own endpoints.
@@ -82,6 +87,18 @@ An object representing the payment details of a donation.
 |authorization_stored |boolean	|Indicates if payment information has been stored for future automatic payments.
 
 
+#### Referrer Data
+
+|Name          |Type      |Description
+|-----------    |-----------|--------------
+|referrer_data.source	|string    |The source code that was used when this donation was created. Typically used to track individual links, such as a post on social media or a link in a specific email. (ex: "facebook-101016-mainpage")
+|referrer_data.referrer	|string    |The code or ID representing a person or group that referred this donation. Typically used to track which person referred the person who made this donation. (ex: "jane-doe")
+|referrer_data.website	|string    |The top level domain of the website where the person clicked from to then subsequently make this donation. (ex: "facebook.com")
+|referrer_data.url	|string    |The specific URL where the person clicked from to then subsequently make this donation. (ex: "https://facebook.com/posts/12345")
+
+_[Back to top...](#)_
+
+
 ## Links
 
 | Name          | Type      | Description
@@ -91,6 +108,8 @@ An object representing the payment details of a donation.
 |fundraising_page			|[Fundraising Page*](fundraising_pages.html)  		|A link to a Fundraising Page resource representing the fundraising page on which this donation was submitted.
 |attendance | [Attendance*](attendances.html) | A link to the Attendance resource which was "purchased" with this donation. Typically used to represent tickets sold for events. There is no requirement that the amount of this donation is equal to the cost of the tickets represented in the linked Attendance.
 
+_[Back to top...](#)_
+
 ## Helpers
 
 {% include helpers_intro.md %}
@@ -99,6 +118,8 @@ An object representing the payment details of a donation.
 |-----------------------|--------------
 |[record_donation_helper](record_donation.html)| Provides a simple method for adding a new donation and a new person to a system at the same time.
 
+_[Back to top...](#)_
+
 
 ## Related Resources
 
@@ -106,6 +127,8 @@ An object representing the payment details of a donation.
 * [Fundraising Page](fundraising_pages.html)
 * [Person](people.html)
 * [Attendace](attendances.html)
+
+_[Back to top...](#)_
 
 
 
@@ -149,6 +172,12 @@ Cache-Control: max-age=0, private, must-revalidate
             },
             {
                 "href": "https://osdi-sample-system.org/api/v1/fundraising_pages/c945d6fe-929e-11e3-a2e9-12313d316c29/donations/1efc3644-af25-4253-90b8-a0baf12dbd1e"
+            },
+            {
+                "href": "https://osdi-sample-system.org/api/v1/fundraising_pages/c945d6fe-929e-11e3-a2e9-12313d316c29/donations/c945d6fe-929e-11e3-a2e9-12313d316c29"
+            },
+            {
+                "href": "https://osdi-sample-system.org/api/v1/fundraising_pages/c945d6fe-929e-11e3-a2e9-12313d316c29/donations/adb951cb-51f9-420e-b7e6-de953195ec86"
             },
             //(truncated for brevity)
         ],
@@ -198,6 +227,12 @@ Cache-Control: max-age=0, private, must-revalidate
                         "legal_name": "Joe for Congress"
                    }
                 ],
+                "referrer_data": {
+                    "source": "facebook-101016-mainpage",
+                    "referrer": "jane-doe",
+                    "website": "facebook.com",
+                    "url": "https://facebook.com/posts/12345"
+                },
                 "_links": {
                     "self": {
                         "href": "https://osdi-sample-system.org/api/v1/fundraising_pages/c945d6fe-929e-11e3-a2e9-12313d316c29/donations/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3"
@@ -235,6 +270,9 @@ Cache-Control: max-age=0, private, must-revalidate
                         "legal_name": "Obama for America"
                     }
                 ],
+                "referrer_data": {
+                    "source": "email-101116-subjecttest1"
+                },
                 "_links": {
                     "self": {
                         "href": "https://osdi-sample-system.org/api/v1/fundraising_pages/c945d6fe-929e-11e3-a2e9-12313d316c29/donations/1efc3644-af25-4253-90b8-a0baf12dbd1e"
@@ -249,7 +287,7 @@ Cache-Control: max-age=0, private, must-revalidate
             },
             {
                 "identifiers": [
-                    "osdi_sample_system:1efc3644-af25-4253-90b8-a0baf12dbdaa"
+                    "osdi_sample_system:c945d6fe-929e-11e3-a2e9-12313d316c29"
                 ],
                 "origin_system": "OSDI Sample System",
                 "created_date": "2014-03-20T20:44:13Z",
@@ -272,9 +310,12 @@ Cache-Control: max-age=0, private, must-revalidate
                         "legal_name": "Obama for America"
                     }
                 ],
+                "referrer_data": {
+                    "source": "event-rsvp-1"
+                },
                 "_links": {
                     "self": {
-                        "href": "https://osdi-sample-system.org/api/v1/fundraising_pages/c945d6fe-929e-11e3-a2e9-12313d316c29/donations/1efc3644-af25-4253-90b8-a0baf12dbd1e"
+                        "href": "https://osdi-sample-system.org/api/v1/fundraising_pages/c945d6fe-929e-11e3-a2e9-12313d316c29/donations/c945d6fe-929e-11e3-a2e9-12313d316c29"
                     },
                     "osdi:fundraising_page": {
                         "href": "https://osdi-sample-system.org/api/v1/fundraising_pages/c945d6fe-929e-11e3-a2e9-12313d316c29"
@@ -289,7 +330,7 @@ Cache-Control: max-age=0, private, must-revalidate
             },
             {
                 "identifiers": [
-                    "osdi_sample_system:1efc3644-af25-4253-90b8-a0baf12dbdbb"
+                    "osdi_sample_system:adb951cb-51f9-420e-b7e6-de953195ec86"
                 ],
                 "origin_system": "OSDI Sample System",
                 "created_date": "2014-03-20T20:44:13Z",
@@ -312,9 +353,12 @@ Cache-Control: max-age=0, private, must-revalidate
                         "legal_name": "Obama for America"
                     }
                 ],
+                "referrer_data": {
+                    "source": "donation-ask-20918"
+                },
                 "_links": {
                     "self": {
-                        "href": "https://osdi-sample-system.org/api/v1/fundraising_pages/c945d6fe-929e-11e3-a2e9-12313d316c29/donations/1efc3644-af25-4253-90b8-a0baf12dbd1e"
+                        "href": "https://osdi-sample-system.org/api/v1/fundraising_pages/c945d6fe-929e-11e3-a2e9-12313d316c29/donations/adb951cb-51f9-420e-b7e6-de953195ec86"
                     },
                     "osdi:fundraising_page": {
                         "href": "https://osdi-sample-system.org/api/v1/fundraising_pages/c945d6fe-929e-11e3-a2e9-12313d316c29"
@@ -386,6 +430,12 @@ Cache-Control: max-age=0, private, must-revalidate
             "legal_name": "Joe for Congress"
        }
     ],
+    "referrer_data": {
+        "source": "facebook-101016-mainpage",
+        "referrer": "jane-doe",
+        "website": "facebook.com",
+        "url": "https://facebook.com/posts/12345"
+    },
     "_links": {
         "self": {
             "href": "https://osdi-sample-system.org/api/v1/fundraising_pages/c945d6fe-929e-11e3-a2e9-12313d316c29/donations/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3"
@@ -445,6 +495,9 @@ OSDI-API-Token:[your api key here]
             "legal_name": "Joe for Congress"
        }
     ],
+    "referrer_data": {
+        "source": "api"
+    },
     "_links" : {
         "osdi:person" : { 
             "href" : "https://actionnetwork.org/api/v1/people/65345d7d-cd24-466a-a698-4a7686ef684f" 
@@ -494,6 +547,9 @@ Cache-Control: max-age=0, private, must-revalidate
             "legal_name": "Joe for Congress"
        }
     ],
+    "referrer_data": {
+        "source": "api"
+    },
     "_links": {
         "self": {
             "href": "https://osdi-sample-system.org/api/v1/fundraising_pages/c945d6fe-929e-11e3-a2e9-12313d316c29/donations/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse"
@@ -571,6 +627,12 @@ Cache-Control: max-age=0, private, must-revalidate
             "legal_name": "Joe for Congress"
        }
     ],
+    "referrer_data": {
+        "source": "facebook-101016-mainpage",
+        "referrer": "jane-doe",
+        "website": "facebook.com",
+        "url": "https://facebook.com/posts/12345"
+    },
     "_links": {
         "self": {
             "href": "https://osdi-sample-system.org/api/v1/fundraising_pages/c945d6fe-929e-11e3-a2e9-12313d316c29/donations/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse"

--- a/outreaches.md
+++ b/outreaches.md
@@ -56,6 +56,7 @@ A list of fields specific to the Outreach resource.
 |duration		|integer		|The duration in seconds of the outreach, if applicable. (ex: duration will only be present on phone outreach types)
 |subject		|string		|The subject of the outreach, if applicable. (ex: subject will only be present on email outreach types)
 |message		|string		|The message of the outreach, if applicable. (ex: message will only be present on email or postal mail outreach types)
+|referrer_data		|[Referrer Data*](#referrer-data)	|An object hash representing referrer and sourcing information about this outreach.
 |targets			|[Target[]](#target)    |An array of target object hashes representing the targets of the outreach.
 
 _[Back to top...](#)_
@@ -64,6 +65,16 @@ _[Back to top...](#)_
 ### Related Objects
 
 These JSON hashes included in the table above are broken out into their own tables for readability, rather than independent resources with their own endpoints.
+
+#### Referrer Data
+
+|Name          |Type      |Description
+|-----------    |-----------|--------------
+|referrer_data.source	|string    |The source code that was used when this outreach was created. Typically used to track individual links, such as a post on social media or a link in a specific email. (ex: "facebook-101016-mainpage")
+|referrer_data.referrer	|string    |The code or ID representing a person or group that referred this outreach. Typically used to track which person referred the person who made this outreach. (ex: "jane-doe")
+|referrer_data.website	|string    |The top level domain of the website where the person clicked from to then subsequently make this outreach. (ex: "facebook.com")
+|referrer_data.url	|string    |The specific URL where the person clicked from to then subsequently make this outreach. (ex: "https://facebook.com/posts/12345")
+
 
 #### Target
 
@@ -178,6 +189,12 @@ Cache-Control: max-age=0, private, must-revalidate
                 "type": "email",
                 "subject": "Vote no!",
                 "message": "Please vote no on HR 100.",
+                "referrer_data": {
+                    "source": "facebook-101016-mainpage",
+                    "referrer": "jane-doe",
+                    "website": "facebook.com",
+                    "url": "https://facebook.com/posts/12345"
+                },
                 "targets": [
 	                {
 	                    "title": "Senator",
@@ -217,6 +234,9 @@ Cache-Control: max-age=0, private, must-revalidate
                 "type": "email",
                 "subject": "Don't do it!",
                 "message": "Vote no tomorrow!",
+                "referrer_data": {
+                    "source": "email-101116-subjecttest1"
+                },
                 "targets": [
 	                {
 	                    "title": "Senator",
@@ -279,6 +299,12 @@ Cache-Control: max-age=0, private, must-revalidate
     "type": "email",
     "subject": "Vote no!",
     "message": "Please vote no on HR 100.",
+    "referrer_data": {
+        "source": "facebook-101016-mainpage",
+        "referrer": "jane-doe",
+        "website": "facebook.com",
+        "url": "https://facebook.com/posts/12345"
+    },
     "targets": [
 	    {
 	        "title": "Senator",
@@ -334,6 +360,9 @@ OSDI-API-Token:[your api key here]
     "action_date": "2014-03-18T11:02:15Z",
     "type": "phone",
     "duration": 120,
+    "referrer_data": {
+        "source": "api"
+    },
     "targets": [
 	    {
 	        "title": "Senator",
@@ -376,6 +405,9 @@ Cache-Control: max-age=0, private, must-revalidate
     "action_date": "2014-03-18T11:02:15Z",
     "type": "phone",
     "duration": 120,
+    "referrer_data": {
+        "source": "api"
+    },
     "targets": [
 	    {
 	        "title": "Senator",
@@ -446,6 +478,12 @@ Cache-Control: max-age=0, private, must-revalidate
     "action_date": "2014-03-17T11:02:15Z",
     "type": "phone",
     "duration": 120,
+    "referrer_data": {
+        "source": "facebook-101016-mainpage",
+        "referrer": "jane-doe",
+        "website": "facebook.com",
+        "url": "https://facebook.com/posts/12345"
+    },
     "targets": [
 	    {
 	        "title": "Senator",

--- a/record_attendance.md
+++ b/record_attendance.md
@@ -63,6 +63,7 @@ A list of fields specific for POSTing via the Record Attendance Helper.
 |status			|enum			|The attendee's response status. One of "declined", "tentative", "accepted", or "needs action".
 |attended		|boolean		|For event RSVPs, represents whether the person actually attended the event or not. For ticketed events, field should be absent, as it's superseded by the `attended` field in the `ticket` object.
 |comment		|string			|An optional comment from the attendee.
+|referrer_data		|[Referrer Data*](#referrer-data)	|An object hash representing referrer and sourcing information about this attendance.
 |person			|[Person*](#person)	|An object hash representing the person who made the attendance, or bought the tickets in the case of a ticketed event.
 |tickets		|[Tickets[]](#tickets)	|If this event is a ticketed event, an array of object hashes representing each ticket purchased as part of this attendance. (ex: One $5 general admission ticket for Sam and two $50 VIP tickets for Sally and Saul.)
 
@@ -78,6 +79,15 @@ _[Back to top...](#)_
 ### Related Objects
 
 These JSON hashes included in the table above are broken out into their own tables for readability, rather than independent resources with their own endpoints.
+
+#### Referrer Data
+
+|Name          |Type      |Description
+|-----------    |-----------|--------------
+|referrer_data.source	|string    |The source code that was used when this attendance was created. Typically used to track individual links, such as a post on social media or a link in a specific email. (ex: "facebook-101016-mainpage")
+|referrer_data.referrer	|string    |The code or ID representing a person or group that referred this attendance. Typically used to track which person referred the person who made this attendance. (ex: "jane-doe")
+|referrer_data.website	|string    |The top level domain of the website where the person clicked from to then subsequently make this attendance. (ex: "facebook.com")
+|referrer_data.url	|string    |The specific URL where the person clicked from to then subsequently make this attendance. (ex: "https://facebook.com/posts/12345")
 
 #### Tickets
 
@@ -173,6 +183,12 @@ OSDI-API-Token:[your api key here]
     "origin_system": "OpenSupporter",
     "action_date": "2014-03-18T11:02:15Z",
     "status": "accepted",
+    "referrer_data": {
+        "source": "facebook-101016-mainpage",
+        "referrer": "jane-doe",
+        "website": "facebook.com",
+        "url": "https://facebook.com/posts/12345"
+    },
 {% include helper_action_examples.md %}
 }
 ```
@@ -195,6 +211,12 @@ Cache-Control: max-age=0, private, must-revalidate
     "action_date": "2014-03-18T11:02:15Z",
     "origin_system": "OpenSupporter",
     "status": "accepted",
+    "referrer_data": {
+        "source": "facebook-101016-mainpage",
+        "referrer": "jane-doe",
+        "website": "facebook.com",
+        "url": "https://facebook.com/posts/12345"
+    },
     "_links": {
         "self": {
             "href": "https://osdi-sample-system.org/api/v1/events/c945d6fe-929e-11e3-a2e9-12313d316c29/attendances/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse"
@@ -265,6 +287,12 @@ OSDI-API-Token:[your api key here]
     "origin_system": "OpenSupporter",
     "action_date": "2014-03-18T11:02:15Z",
     "status": "accepted",
+    "referrer_data": {
+        "source": "facebook-101016-mainpage",
+        "referrer": "jane-doe",
+        "website": "facebook.com",
+        "url": "https://facebook.com/posts/12345"
+    },
     "tickets": [
 	    {
 	        "title": "General Admission",
@@ -325,6 +353,12 @@ Cache-Control: max-age=0, private, must-revalidate
     "action_date": "2014-03-18T11:02:15Z",
     "origin_system": "OpenSupporter",
     "status": "accepted",
+    "referrer_data": {
+        "source": "facebook-101016-mainpage",
+        "referrer": "jane-doe",
+        "website": "facebook.com",
+        "url": "https://facebook.com/posts/12345"
+    },
     "tickets": [
 	    {
 	        "title": "General Admission",
@@ -434,6 +468,12 @@ POST https://osdi-sample-system.org/api/v1/events/c945d6fe-929e-11e3-a2e9-12313d
     "origin_system": "OpenSupporter",
     "action_date": "2014-03-18T11:02:15Z",
     "status": "accepted",
+    "referrer_data": {
+        "source": "facebook-101016-mainpage",
+        "referrer": "jane-doe",
+        "website": "facebook.com",
+        "url": "https://facebook.com/posts/12345"
+    },
 {% include helper_action_examples.md %}
 }
 ```

--- a/record_donation.md
+++ b/record_donation.md
@@ -68,6 +68,7 @@ A list of fields specific for POSTing via the Record Donation Helper.
 |voided			|boolean	|Indicates if the donation has been voided.
 |voided_date  	|datetime		|Date of the void.
 |url			|string		|URL at which the donation was taken.
+|referrer_data		|[Referrer Data*](#referrer-data)	|An object hash representing referrer and sourcing information about this donation.
 |person			|[Person*](#person)	|An object hash representing the person who made the donation.
 
 _[Back to top...](#)_
@@ -104,6 +105,16 @@ An object representing the payment details of a donation.
 |method			|enum		|A flexible enumeration of "Credit Card", "Check", "Cash", or "Electronic Funds Transfer".
 |reference_number |string		|A check number, transaction ID, or some other information referencing the payment.
 |authorization_stored |boolean	|Indicates if payment information has been stored for future automatic payments.
+
+
+#### Referrer Data
+
+|Name          |Type      |Description
+|-----------    |-----------|--------------
+|referrer_data.source	|string    |The source code that was used when this donation was created. Typically used to track individual links, such as a post on social media or a link in a specific email. (ex: "facebook-101016-mainpage")
+|referrer_data.referrer	|string    |The code or ID representing a person or group that referred this donation. Typically used to track which person referred the person who made this donation. (ex: "jane-doe")
+|referrer_data.website	|string    |The top level domain of the website where the person clicked from to then subsequently make this donation. (ex: "facebook.com")
+|referrer_data.url	|string    |The specific URL where the person clicked from to then subsequently make this donation. (ex: "https://facebook.com/posts/12345")
 
 #### Person
 
@@ -209,7 +220,13 @@ OSDI-API-Token:[your api key here]
     ],
     "osdi:attendance": {
         "href": "https://osdi-sample-system.org/api/v1/events/c945d6fe-929e-11e3-a2e9-12313d316c29/attendances/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc"
-    }
+    },
+    "referrer_data": {
+        "source": "facebook-101016-mainpage",
+        "referrer": "jane-doe",
+        "website": "facebook.com",
+        "url": "https://facebook.com/posts/12345"
+    },
 {% include helper_action_examples.md %}
 }
 ```
@@ -255,6 +272,12 @@ Cache-Control: max-age=0, private, must-revalidate
             "legal_name": "Joe for Congress"
        }
     ],
+    "referrer_data": {
+        "source": "facebook-101016-mainpage",
+        "referrer": "jane-doe",
+        "website": "facebook.com",
+        "url": "https://facebook.com/posts/12345"
+    },
     "_links": {
         "self": {
             "href": "https://osdi-sample-system.org/api/v1/fundraising_pages/c945d6fe-929e-11e3-a2e9-12313d316c29/doantions/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse"
@@ -352,6 +375,12 @@ POST https://osdi-sample-system.org/api/v1/fundraising_pages/c945d6fe-929e-11e3-
             "legal_name": "Joe for Congress"
        }
     ],
+    "referrer_data": {
+        "source": "facebook-101016-mainpage",
+        "referrer": "jane-doe",
+        "website": "facebook.com",
+        "url": "https://facebook.com/posts/12345"
+    },
 {% include helper_action_examples.md %}
 }
 ```

--- a/record_outreach.md
+++ b/record_outreach.md
@@ -62,6 +62,7 @@ A list of fields specific for POSTing via the Record Outreach Helper.
 |duration		|integer		|The duration in seconds of the outreach, if applicable. (ex: duration will only be present on phone outreach types)
 |subject		|string		|The subject of the outreach, if applicable. (ex: subject will only be present on email outreach types)
 |message		|string		|The message of the outreach, if applicable. (ex: message will only be present on email or postal mail outreach types)
+|referrer_data		|[Referrer Data*](#referrer-data)	|An object hash representing referrer and sourcing information about this outreach.
 |targets			|[Target[]](#target)    |A array of target object hashes representing the targets of the outreach.
 |person			|[Person*](#person)	|An object hash representing the person who made the outreach.
 
@@ -78,6 +79,15 @@ _[Back to top...](#)_
 ### Related Objects
 
 These JSON hashes included in the table above are broken out into their own tables for readability, rather than independent resources with their own endpoints.
+
+#### Referrer Data
+
+|Name          |Type      |Description
+|-----------    |-----------|--------------
+|referrer_data.source	|string    |The source code that was used when this outreach was created. Typically used to track individual links, such as a post on social media or a link in a specific email. (ex: "facebook-101016-mainpage")
+|referrer_data.referrer	|string    |The code or ID representing a person or group that referred this outreach. Typically used to track which person referred the person who made this outreach. (ex: "jane-doe")
+|referrer_data.website	|string    |The top level domain of the website where the person clicked from to then subsequently make this outreach. (ex: "facebook.com")
+|referrer_data.url	|string    |The specific URL where the person clicked from to then subsequently make this outreach. (ex: "https://facebook.com/posts/12345")
 
 #### Target
 
@@ -170,6 +180,12 @@ OSDI-API-Token:[your api key here]
     "action_date": "2014-03-18T11:02:15Z",
     "type": "phone",
     "duration": 120,
+    "referrer_data": {
+        "source": "facebook-101016-mainpage",
+        "referrer": "jane-doe",
+        "website": "facebook.com",
+        "url": "https://facebook.com/posts/12345"
+    },
     "targets": [
 	    {
 	        "title": "Senator",
@@ -209,6 +225,12 @@ Cache-Control: max-age=0, private, must-revalidate
     "origin_system": "OpenSupporter",
     "type": "phone",
     "duration": 120,
+    "referrer_data": {
+        "source": "facebook-101016-mainpage",
+        "referrer": "jane-doe",
+        "website": "facebook.com",
+        "url": "https://facebook.com/posts/12345"
+    },
     "targets": [
 	    {
 	        "title": "Senator",
@@ -297,6 +319,12 @@ POST https://osdi-sample-system.org/api/v1/advocacy_campaigns/c945d6fe-929e-11e3
     "action_date": "2014-03-18T11:02:15Z",
     "type": "phone",
     "duration": 120,
+    "referrer_data": {
+        "source": "facebook-101016-mainpage",
+        "referrer": "jane-doe",
+        "website": "facebook.com",
+        "url": "https://facebook.com/posts/12345"
+    },
     "targets": [
 	    {
 	        "title": "Senator",

--- a/record_signature.md
+++ b/record_signature.md
@@ -59,6 +59,7 @@ A list of fields specific for POSTing via the Record Signature Helper.
 |origin_system		|string     |A human readable identifier of the system where this signature was created. (ex: "OSDI System")
 |action_date		|string		|The date and time the signature was made by the person.
 |comments		|string			|The comments left by the person when the signature was created.
+|referrer_data		|[Referrer Data*](#referrer-data)	|An object hash representing referrer and sourcing information about this signature.
 |person			|[Person*](#person)	|An object hash representing the person who made the submission.
 
 
@@ -73,6 +74,15 @@ _[Back to top...](#)_
 ### Related Objects
 
 These JSON hashes included in the table above are broken out into their own tables for readability, rather than independent resources with their own endpoints.
+
+#### Referrer Data
+
+|Name          |Type      |Description
+|-----------    |-----------|--------------
+|referrer_data.source	|string    |The source code that was used when this signature was created. Typically used to track individual links, such as a post on social media or a link in a specific email. (ex: "facebook-101016-mainpage")
+|referrer_data.referrer	|string    |The code or ID representing a person or group that referred this signature. Typically used to track which person referred the person who made this signature. (ex: "jane-doe")
+|referrer_data.website	|string    |The top level domain of the website where the person clicked from to then subsequently make this signature. (ex: "facebook.com")
+|referrer_data.url	|string    |The specific URL where the person clicked from to then subsequently make this signature. (ex: "https://facebook.com/posts/12345")
 
 #### Person
 
@@ -155,6 +165,12 @@ OSDI-API-Token:[your api key here]
     "origin_system": "OpenSupporter",
     "action_date": "2014-03-18T11:02:15Z",
     "comments": "Support our campaign!",
+    "referrer_data": {
+        "source": "facebook-101016-mainpage",
+        "referrer": "jane-doe",
+        "website": "facebook.com",
+        "url": "https://facebook.com/posts/12345"
+    },
 {% include helper_action_examples.md %}
 }
 ```
@@ -177,6 +193,12 @@ Cache-Control: max-age=0, private, must-revalidate
     "action_date": "2014-03-18T11:02:15Z",
     "origin_system": "OpenSupporter",
     "comments": "Support our campaign!",
+    "referrer_data": {
+        "source": "facebook-101016-mainpage",
+        "referrer": "jane-doe",
+        "website": "facebook.com",
+        "url": "https://facebook.com/posts/12345"
+    },
     "_links": {
         "self": {
             "href": "https://osdi-sample-system.org/api/v1/petitions/c945d6fe-929e-11e3-a2e9-12313d316c29/signatures/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse"
@@ -248,6 +270,12 @@ POST https://osdi-sample-system.org/api/v1/petitions/c945d6fe-929e-11e3-a2e9-123
     "origin_system": "OpenSupporter",
     "action_date": "2014-03-18T11:02:15Z",
     "comments": "Support our campaign!",
+    "referrer_data": {
+        "source": "facebook-101016-mainpage",
+        "referrer": "jane-doe",
+        "website": "facebook.com",
+        "url": "https://facebook.com/posts/12345"
+    },
 {% include helper_action_examples.md %}
 }
 ```

--- a/record_submission.md
+++ b/record_submission.md
@@ -58,6 +58,7 @@ A list of fields specific for POSTing via the Record Submission Helper.
 |-----------    |-----------|-----------|--------------
 |origin_system		|string     |A human readable identifier of the system where this submission was created. (ex: "OSDI System")
 |action_date		|string		|The date and time the submission was made by the person.
+|referrer_data		|[Referrer Data*](#referrer-data)	|An object hash representing referrer and sourcing information about this submission.
 |person			|[Person*](#person)	|An object hash representing the person who made the submission.
 
 _[Back to top...](#)_
@@ -71,6 +72,15 @@ _[Back to top...](#)_
 ### Related Objects
 
 These JSON hashes included in the table above are broken out into their own tables for readability, rather than independent resources with their own endpoints.
+
+#### Referrer Data
+
+|Name          |Type      |Description
+|-----------    |-----------|--------------
+|referrer_data.source	|string    |The source code that was used when this submission was created. Typically used to track individual links, such as a post on social media or a link in a specific email. (ex: "facebook-101016-mainpage")
+|referrer_data.referrer	|string    |The code or ID representing a person or group that referred this submission. Typically used to track which person referred the person who made this signature. (ex: "jane-doe")
+|referrer_data.website	|string    |The top level domain of the website where the person clicked from to then subsequently make this submission. (ex: "facebook.com")
+|referrer_data.url	|string    |The specific URL where the person clicked from to then subsequently make this submission. (ex: "https://facebook.com/posts/12345")
 
 #### Person
 
@@ -151,6 +161,12 @@ OSDI-API-Token:[your api key here]
     ],
     "origin_system": "OpenSupporter",
     "action_date": "2014-03-18T11:02:15Z",
+    "referrer_data": {
+        "source": "facebook-101016-mainpage",
+        "referrer": "jane-doe",
+        "website": "facebook.com",
+        "url": "https://facebook.com/posts/12345"
+    },
 {% include helper_action_examples.md %}
 }
 ```
@@ -172,6 +188,12 @@ Cache-Control: max-age=0, private, must-revalidate
     "modified_date": "2014-03-20T21:04:31Z",
     "action_date": "2014-03-18T11:02:15Z",
     "origin_system": "OpenSupporter",
+    "referrer_data": {
+        "source": "facebook-101016-mainpage",
+        "referrer": "jane-doe",
+        "website": "facebook.com",
+        "url": "https://facebook.com/posts/12345"
+    },
     "_links": {
         "self": {
             "href": "https://osdi-sample-system.org/api/v1/forms/c945d6fe-929e-11e3-a2e9-12313d316c29/submissions/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse"
@@ -245,6 +267,12 @@ POST https://osdi-sample-system.org/api/v1/forms/c945d6fe-929e-11e3-a2e9-12313d3
     ],
     "origin_system": "OpenSupporter",
     "action_date": "2014-03-18T11:02:15Z",
+    "referrer_data": {
+        "source": "facebook-101016-mainpage",
+        "referrer": "jane-doe",
+        "website": "facebook.com",
+        "url": "https://facebook.com/posts/12345"
+    },
 {% include helper_action_examples.md %}
 }
 ```

--- a/signatures.md
+++ b/signatures.md
@@ -16,6 +16,7 @@ Signatures are a type of action that a user may take by completing a petition. S
 * [Fields](#fields)
     * [Common Fields](#common-fields)
     * [Signature Fields](#signature-fields)  
+    * [Related Objects](#related-objects)
     * [Links](#links)
 * [Helpers](#helpers)
 * [Related Resources](#related-resources)
@@ -52,6 +53,23 @@ A list of fields specific to the Signature resource.
 |origin_system		|string     |A human readable identifier of the system where this signature was created. (ex: "OSDI System")
 |action_date		|string		|The date and time the signature was made by the person.
 |comments		|string			|The comments left by the person when the signature was created.
+|referrer_data		|[Referrer Data*](#referrer-data)	|An object hash representing referrer and sourcing information about this signature.
+
+_[Back to top...](#)_
+
+
+### Related Objects
+
+These JSON hashes included in the table above are broken out into their own tables for readability, rather than independent resources with their own endpoints.
+
+#### Referrer Data
+
+|Name          |Type      |Description
+|-----------    |-----------|--------------
+|referrer_data.source	|string    |The source code that was used when this signature was created. Typically used to track individual links, such as a post on social media or a link in a specific email. (ex: "facebook-101016-mainpage")
+|referrer_data.referrer	|string    |The code or ID representing a person or group that referred this signature. Typically used to track which person referred the person who made this signature. (ex: "jane-doe")
+|referrer_data.website	|string    |The top level domain of the website where the person clicked from to then subsequently make this signature. (ex: "facebook.com")
+|referrer_data.url	|string    |The specific URL where the person clicked from to then subsequently make this signature. (ex: "https://facebook.com/posts/12345")
 
 _[Back to top...](#)_
 
@@ -154,6 +172,12 @@ Cache-Control: max-age=0, private, must-revalidate
                 "modified_date": "2014-03-20T21:04:31Z",
                 "action_date": "2014-03-18T11:02:15Z",
                 "comments": "Please stop doing the bad thing!",
+                "referrer_data": {
+                    "source": "facebook-101016-mainpage",
+                    "referrer": "jane-doe",
+                    "website": "facebook.com",
+                    "url": "https://facebook.com/posts/12345"
+                },
                 "_links": {
                     "self": {
                         "href": "https://osdi-sample-system.org/api/v1/petitions/c945d6fe-929e-11e3-a2e9-12313d316c29/signatures/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3"
@@ -174,6 +198,9 @@ Cache-Control: max-age=0, private, must-revalidate
                 "created_date": "2014-03-20T20:44:13Z",
                 "modified_date": "2014-03-20T20:44:13Z",
                 "action_date": "2014-03-12T01:45:34Z",
+                "referrer_data": {
+                    "source": "email-101116-subjecttest1"
+                },
                 "_links": {
                     "self": {
                         "href": "https://osdi-sample-system.org/api/v1/petitions/c945d6fe-929e-11e3-a2e9-12313d316c29/signatures/1efc3644-af25-4253-90b8-a0baf12dbd1e"
@@ -225,6 +252,12 @@ Cache-Control: max-age=0, private, must-revalidate
     "modified_date": "2014-03-20T21:04:31Z",
     "action_date": "2014-03-18T11:02:15Z",
     "comments": "Please stop doing the bad thing!",
+    "referrer_data": {
+        "source": "facebook-101016-mainpage",
+        "referrer": "jane-doe",
+        "website": "facebook.com",
+        "url": "https://facebook.com/posts/12345"
+    },
     "_links": {
         "self": {
             "href": "https://osdi-sample-system.org/api/v1/petitions/c945d6fe-929e-11e3-a2e9-12313d316c29/signatures/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3"
@@ -263,6 +296,9 @@ OSDI-API-Token:[your api key here]
     "origin_system": "OpenSupporter",
     "action_date": "2014-03-18T11:02:15Z",
     "comments": "Please stop!",
+    "referrer_data": {
+        "source": "api"
+    },
     "_links" : {
         "osdi:person" : { 
             "href" : "https://actionnetwork.org/api/v1/people/65345d7d-cd24-466a-a698-4a7686ef684f" 
@@ -288,6 +324,9 @@ Cache-Control: max-age=0, private, must-revalidate
     "modified_date": "2014-03-20T21:04:31Z",
     "action_date": "2014-03-18T11:02:15Z",
     "comments": "Please stop!",
+    "referrer_data": {
+        "source": "api"
+    },
     "_links": {
         "self": {
             "href": "https://osdi-sample-system.org/api/v1/petitions/c945d6fe-929e-11e3-a2e9-12313d316c29/signatures/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse"
@@ -341,6 +380,12 @@ Cache-Control: max-age=0, private, must-revalidate
     "modified_date": "2014-03-20T22:04:31Z",
     "action_date": "2014-03-17T11:02:15Z",
     "comments": "Please stop!",
+    "referrer_data": {
+        "source": "facebook-101016-mainpage",
+        "referrer": "jane-doe",
+        "website": "facebook.com",
+        "url": "https://facebook.com/posts/12345"
+    },
     "_links": {
         "self": {
             "href": "https://osdi-sample-system.org/api/v1/petitions/c945d6fe-929e-11e3-a2e9-12313d316c29/signatures/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse"

--- a/submissions.md
+++ b/submissions.md
@@ -16,6 +16,7 @@ Submissions are a type of action that a user may take by completing a form. Subm
 * [Fields](#fields)
     * [Common Fields](#common-fields)
     * [Submission Fields](#submission-fields)  
+    * [Related Objects](#related-objects)
     * [Links](#links)
 * [Helpers](#helpers)
 * [Related Resources](#related-resources)
@@ -51,6 +52,25 @@ A list of fields specific to the Submission resource.
 |-----------    |-----------|-----------|--------------
 |origin_system		|string     |A human readable identifier of the system where this submission was created. (ex: "OSDI System")
 |action_date		|string		|The date and time the submission was made by the person.
+|referrer_data		|[Referrer Data*](#referrer-data)	|An object hash representing referrer and sourcing information about this submission.
+
+
+_[Back to top...](#)_
+
+
+
+### Related Objects
+
+These JSON hashes included in the table above are broken out into their own tables for readability, rather than independent resources with their own endpoints.
+
+#### Referrer Data
+
+|Name          |Type      |Description
+|-----------    |-----------|--------------
+|referrer_data.source	|string    |The source code that was used when this submission was created. Typically used to track individual links, such as a post on social media or a link in a specific email. (ex: "facebook-101016-mainpage")
+|referrer_data.referrer	|string    |The code or ID representing a person or group that referred this submission. Typically used to track which person referred the person who made this signature. (ex: "jane-doe")
+|referrer_data.website	|string    |The top level domain of the website where the person clicked from to then subsequently make this submission. (ex: "facebook.com")
+|referrer_data.url	|string    |The specific URL where the person clicked from to then subsequently make this submission. (ex: "https://facebook.com/posts/12345")
 
 _[Back to top...](#)_
 
@@ -143,6 +163,12 @@ Cache-Control: max-age=0, private, must-revalidate
                 "created_date": "2014-03-20T21:04:31Z",
                 "modified_date": "2014-03-20T21:04:31Z",
                 "action_date": "2014-03-18T11:02:15Z",
+                "referrer_data": {
+                    "source": "facebook-101016-mainpage",
+                    "referrer": "jane-doe",
+                    "website": "facebook.com",
+                    "url": "https://facebook.com/posts/12345"
+                },
                 "_links": {
                     "self": {
                         "href": "https://osdi-sample-system.org/api/v1/forms/c945d6fe-929e-11e3-a2e9-12313d316c29/submissions/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3"
@@ -166,6 +192,9 @@ Cache-Control: max-age=0, private, must-revalidate
                 "created_date": "2014-03-20T20:44:13Z",
                 "modified_date": "2014-03-20T20:44:13Z",
                 "action_date": "2014-03-12T01:45:34Z",
+                "referrer_data": {
+                    "source": "email-101116-subjecttest1"
+                },
                 "_links": {
                     "self": {
                         "href": "https://osdi-sample-system.org/api/v1/forms/c945d6fe-929e-11e3-a2e9-12313d316c29/submissions/1efc3644-af25-4253-90b8-a0baf12dbd1e"
@@ -219,6 +248,12 @@ Cache-Control: max-age=0, private, must-revalidate
     "created_date": "2014-03-20T21:04:31Z",
     "modified_date": "2014-03-20T21:04:31Z",
     "action_date": "2014-03-18T11:02:15Z",
+    "referrer_data": {
+        "source": "facebook-101016-mainpage",
+        "referrer": "jane-doe",
+        "website": "facebook.com",
+        "url": "https://facebook.com/posts/12345"
+    },
     "_links": {
         "self": {
             "href": "https://osdi-sample-system.org/api/v1/forms/c945d6fe-929e-11e3-a2e9-12313d316c29/submissions/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3"
@@ -259,6 +294,9 @@ OSDI-API-Token:[your api key here]
     ],
     "origin_system": "OpenSupporter",
     "action_date": "2014-03-18T11:02:15Z",
+    "referrer_data": {
+        "source": "api"
+    },
     "_links" : {
         "osdi:person" : { 
             "href" : "https://actionnetwork.org/api/v1/people/65345d7d-cd24-466a-a698-4a7686ef684f" 
@@ -283,6 +321,9 @@ Cache-Control: max-age=0, private, must-revalidate
     "created_date": "2014-03-20T21:04:31Z",
     "modified_date": "2014-03-20T21:04:31Z",
     "action_date": "2014-03-18T11:02:15Z",
+    "referrer_data": {
+        "source": "api"
+    },
     "_links": {
         "self": {
             "href": "https://osdi-sample-system.org/api/v1/forms/c945d6fe-929e-11e3-a2e9-12313d316c29/submissions/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse"
@@ -338,6 +379,12 @@ Cache-Control: max-age=0, private, must-revalidate
     "created_date": "2014-03-20T21:04:31Z",
     "modified_date": "2014-03-20T22:04:31Z",
     "action_date": "2014-03-17T11:02:15Z",
+    "referrer_data": {
+        "source": "facebook-101016-mainpage",
+        "referrer": "jane-doe",
+        "website": "facebook.com",
+        "url": "https://facebook.com/posts/12345"
+    },
     "_links": {
         "self": {
             "href": "https://osdi-sample-system.org/api/v1/forms/c945d6fe-929e-11e3-a2e9-12313d316c29/submissions/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse"


### PR DESCRIPTION
Not ready to merge, but a first draft. Only on attendances for now, but will eventually expand.

Questions for discussion:

- do folks think all three of these fields are applicable across applications? I think at least referrers and sources are present on more than just Action Network. Not sure if others track website referrals like we do.
- what resources does this go on? I think it goes on all "child" resources, or at least most. So, attendances (events), signatures (petitions), submissions (forms), donations (fundraising_pages), outreaches (advocacy_campaigns). Probably also canvass_responses? answers? And probably **not** taggings or items?