### PR TITLE
add share_url to share_options items specific to service (e.g. facebook, twitter, etc)

### DIFF
--- a/_includes/share_options_main_objects.md
+++ b/_includes/share_options_main_objects.md
@@ -1,3 +1,3 @@
-|share_url			|string		|A URL string pointing to the page that will be shared when this content is shared.
+|share_url			|string		|A URL string pointing to the page that will be shared when this content is shared. (This may be subsumed by a particular share_option's share_url)
 |total_shares	|integer	|A computed property representing the current count of the total number of times the content has been shared by activists.
 |share_options	|[ShareOptions[]](#share-options)	|An array of share options objects representing the default language and attributes used when an activist shares this content via various mediums. More than one `share_options` object is allowed. Depending on server implementations, these could represent different share language variations to test or rotate. 

--- a/_includes/share_options_related_objects.md
+++ b/_includes/share_options_related_objects.md
@@ -14,6 +14,7 @@
 |facebook_share.description |string    |The description of the post created when an activist shares content on Facebook.
 |facebook_share.image |string    |The URL of an image that goes with post created when an activist shares content on Facebook.
 |facebook_share.total_shares		|integer	|A computed property representing the current count of the total number of times the content has been shared on Facebook.
+|facebook_share.share_url		|string        	|A URL string pointing to the page that is used specifically for Facebook sharing
 
 #### Twitter Share
 
@@ -21,7 +22,7 @@
 |-----------    |-----------|--------------
 |twitter_share.message |string    |The text of the post created when an activist shares content on Twitter. Some systems may use templating or appends to insert the `share_url` into the tweet automatically.
 |twitter_share.total_shares		|integer	|A computed property representing the current count of the total number of times the content has been shared on Twitter.
-
+|twitter_share.share_url		|string        	|A URL string pointing to the page that is used specifically for Twitter sharing
 
 #### Email Share
 
@@ -30,3 +31,4 @@
 |email_share.subject |string    |The subject line of the email created when an activist shares content via email.
 |email_share.body |string    |The body text of the email created when an activist shares content via email. Some systems may use templating or appends to insert the `share_url` into the email body automatically.
 |email_share.total_shares		|integer	|A computed property representing the current count of the total number of times content has been shared via email.
+|email_share.share_url		|string        	|A URL string pointing to the page that is used specifically for email sharing


### PR DESCRIPTION
Both because twitter benefits from short urls, and because a system may want to track sharing on different platforms separately, `share_url` may differ by the context.

I tihnk it's acceptable for implementations to use only the root `share_url` but for those that are share_option-aware, it would be good to standardize an option.