### PR TITLE
Organizations Resource

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -16,6 +16,7 @@
     <li><a href="{{ site.baseurl }}/items.html">Items</a></li>
     <li><a href="{{ site.baseurl }}/lists.html">Lists</a></li>
     <li><a href="{{ site.baseurl }}/messages.html">Messages</a></li>
+    <li><a href="{{ site.baseurl }}/organizations.html">Organizations</a></li>
     <li><a href="{{ site.baseurl }}/outreaches.html">Outreaches</a></li>
     <li><a href="{{ site.baseurl }}/people.html">People</a></li>
     <li><a href="{{ site.baseurl }}/petitions.html">Petitions</a></li>

--- a/events.md
+++ b/events.md
@@ -144,7 +144,7 @@ _[Back to top...](#)_
 |-----------    |-----------|-----------|--------------
 |self			|[Event*](events.html)	|A self-referential link to the event.
 |creator		|[Person*](people.html)  		|A link to a single Person resource representing the creator of the event.
-|sponsors		|[Organizations[]*](organizations.html)  		|A link to a collection of Organization resources that are sponsoring or the organization(s) responsible for hosting the event.
+|sponsor		|[Organization*](organizations.html)  		|A link to an Organization resource that is responsible for creating the event and/or is the primary supporting/sponsoring organization.
 |organizer		|[Person*](people.html)  		|A link to a single Person resource representing the organizer of the event.
 |modified_by	|[Person* ](people.html) 		|A link to a Person resource representing the last editor of this event.
 |attendances	|[Attendances[]*](attendances.html)	|A link to the collection of Attendance resources for this event.

--- a/events.md
+++ b/events.md
@@ -300,6 +300,9 @@ Cache-Control: max-age=0, private, must-revalidate
                     "osdi:creator": {
                         "href": "https://osdi-sample-system.org/api/v1/people/65345d7d-cd24-466a-a698-4a7686ef684f"
                     },
+                    "osdi:sponsor": {
+                        "href": "https://osdi-sample-system.org/api/v1/organizations/5d7d6534-cd24-566a-98a6-ef684f4a7686"
+                    },
                     "osdi:organizer": {
                         "href": "https://osdi-sample-system.org/api/v1/people/8a625981-67a4-4457-8b55-2e30b267b2c2"
                     },
@@ -389,6 +392,9 @@ Cache-Control: max-age=0, private, must-revalidate
                     },
                     "osdi:creator": {
                         "href": "https://osdi-sample-system.org/api/v1/people/65345d7d-cd24-466a-a698-4a7686ef684f"
+                    },
+                    "osdi:sponsor": {
+                        "href": "https://osdi-sample-system.org/api/v1/organizations/5d7d6534-cd24-566a-98a6-ef684f4a7686"
                     },
                     "osdi:organizer": {
                         "href": "https://osdi-sample-system.org/api/v1/people/8a625981-67a4-4457-8b55-2e30b267b2c2"
@@ -512,6 +518,9 @@ Cache-Control: max-age=0, private, must-revalidate
         "osdi:creator": {
             "href": "https://osdi-sample-system.org/api/v1/people/65345d7d-cd24-466a-a698-4a7686ef684f"
         },
+        "osdi:sponsor": {
+            "href": "https://osdi-sample-system.org/api/v1/organizations/5d7d6534-cd24-566a-98a6-ef684f4a7686"
+        },
         "osdi:organizer": {
             "href": "https://osdi-sample-system.org/api/v1/people/8a625981-67a4-4457-8b55-2e30b267b2c2"
         },
@@ -626,6 +635,9 @@ Cache-Control: max-age=0, private, must-revalidate
         "osdi:creator": {
             "href": "https://osdi-sample-system.org/api/v1/people/65345d7d-cd24-466a-a698-4a7686ef684f"
         },
+        "osdi:sponsor": {
+            "href": "https://osdi-sample-system.org/api/v1/organizations/5d7d6534-cd24-566a-98a6-ef684f4a7686"
+        },
         "osdi:organizer": {
             "href": "https://osdi-sample-system.org/api/v1/people/8a625981-67a4-4457-8b55-2e30b267b2c2"
         },
@@ -715,6 +727,9 @@ Cache-Control: max-age=0, private, must-revalidate
         },
         "osdi:creator": {
             "href": "https://osdi-sample-system.org/api/v1/people/65345d7d-cd24-466a-a698-4a7686ef684f"
+        },
+        "osdi:sponsor": {
+            "href": "https://osdi-sample-system.org/api/v1/organizations/5d7d6534-cd24-566a-98a6-ef684f4a7686"
         },
         "osdi:organizer": {
             "href": "https://osdi-sample-system.org/api/v1/people/8a625981-67a4-4457-8b55-2e30b267b2c2"

--- a/events.md
+++ b/events.md
@@ -144,6 +144,7 @@ _[Back to top...](#)_
 |-----------    |-----------|-----------|--------------
 |self			|[Event*](events.html)	|A self-referential link to the event.
 |creator		|[Person*](people.html)  		|A link to a single Person resource representing the creator of the event.
+|sponsors		|[Organizations[]*](organizations.html)  		|A link to a collection of Organization resources that are sponsoring or the organization(s) responsible for hosting the event.
 |organizer		|[Person*](people.html)  		|A link to a single Person resource representing the organizer of the event.
 |modified_by	|[Person* ](people.html) 		|A link to a Person resource representing the last editor of this event.
 |attendances	|[Attendances[]*](attendances.html)	|A link to the collection of Attendance resources for this event.

--- a/organizations.md
+++ b/organizations.md
@@ -1,0 +1,929 @@
+---
+layout: default
+title: Person
+---
+
+# Person
+
+This document defines the Person resource. 
+
+People are individual users who are stored in the OSDI system's database in some way.
+
+People have names, email addresses, and other information, and they have associated action histories recording the actions they've taken on the system, such as a list of their signatures on various petitions.
+
+
+### Sections:
+
+* [Endpoints and URL structures](#endpoints-and-url-structures)
+* [Fields](#fields)
+    * [Common Fields](#common-fields)
+    * [People Fields](#people-fields)
+    * [Related Objects](#related-objects)
+    * [Links](#links)
+* [Helpers](#helpers)
+* [Related Resources](#related-resources)
+* [Scenarios](#scenarios)
+    * [Scenario: Retrieving a collection of Person resources (GET)](#scenario-retrieving-a-collection-of-person-resources-get)
+    * [Scenario: Retrieving an individual Person resource (GET)](#scenario-scenario-retrieving-an-individual-person-resource-get)
+    * [Scenario: Creating a new person (POST)](#scenario-creating-a-new-person-post)
+    * [Scenario: Modifying a person (PUT)](#scenario-modifying-a-person-put)
+    * [Scenario: Deleting a person (DELETE)](#scenario-deleting-a-person-delete)
+
+
+{% include endpoints_and_url_structures.md %}
+
+The link relation label for a Person resource is ```osdi:person``` for a single Person resource or ```osdi:people``` for a collection of Person resources.
+
+_[Back to top...](#)_
+
+
+## Fields
+
+{% include fields_intro.md %}
+
+{% include global_fields.md %}
+
+_[Back to top...](#)_
+
+
+### People Fields
+
+A list of fields specific to the Person resource.
+
+|Name          |Type      |Description
+|-----------    |-----------|--------------
+|family_name      |string     |The person's last name.
+|given_name     |string     |The person's first name.
+|additional_name    |string     |An additional name not included in family or given. Usually a middle name.
+|honorific_prefix           |string    |An honorific prefix like "Dr", "Mr", etc...
+|honorific_suffix           |string    |An honorific suffix like "Jr.", "Ph.D", etc...
+|gender         |enum     |The gender binary with which a person most closely identifies, or "Other" if the person identifies with neither. One of "Female", "Male", or "Other".
+|gender_identity|string     |The self-described gender with which a person identifies. While this field is free-form, data should still follow standardized forms whenever possible (i.e. use "Female" and not "female" or "F"). _Examples: If a person self-identifies as "Female", both_ `gender` _and_ `gender_identity` _fields should have a value of "Female". If a person self-identifies as "Transgender Female",_ `gender` _should have a value of "Female" and_ `gender_identity` _should have a value of "Transgender Female"._
+|party_identification   |flexenum     |Flexenum describing the person's politcal party identification. One of "None", "Democratic", "Republican", "Independent", or another free-form string.
+|parties |[Parties[]](#parties)|An array of all party object hashes associated with the person (past and present).
+|source         |string     |Information about the source where this person record was acquired.   _Example: "facebook-ad-october"_
+|ethnicities|strings[]   |A unique string array representing a person's ethnicities.
+|languages_spoken|strings[]      | Unique string array of RFC5646 tags representing the languages spoken by the person. Example: en,  en-US, fr-CA, pt-BR
+|preferred_language | string  | The RFC5646 tag representing the person's preferred language.
+|browser_url		|string		|A URL string pointing to the publicly available person page on the web, such as a public profile page.
+|administrative_url		|string		|A URL string pointing to the person's administrative page on the web, such as a page for managing this person's record.
+|birthdate	|[Birthdate](#birthdate)    |An object hash representing the birthdate of the person.
+|employer|string    |The name of the person's employer.
+|employer_address|[Employer Address](#employer-address)    |An object hash representing the postal address of the person's employer.
+|postal_addresses      |[Postal Addresses[]](#postal-addresses)   |An array of postal address object hashes associated with the person.
+|email_addresses	|[Email Addresses[]](#email-addresses)   |An array of email address object hashes associated with the person.
+|phone_numbers	|[Phone Numbers[]](#phone-numbers)   |An array of phone number object hashes associated with the person.
+|profiles       | [Profiles[]](#profiles) |An array of profile object hashes for online services related to the person.
+|custom_fields	|[Custom Fields](#custom-fields)	|An object hash of key/value pairs associated with the person created by a user rather than a service or vendor.
+
+_[Back to top...](#)_
+
+
+### Related Objects
+
+These JSON hashes included in the table above are broken out into their own tables for readability, rather than independent resources with their own endpoints.
+
+#### Birthdate
+
+|Name          |Type      |Description
+|-----------    |-----------|--------------
+|birthdate.month|integer    |An integer representing the month of the birth date of the person.
+|birthdate.day  |integer    |An integer representing the day of the birth date of the person.
+|birthdate.year|integer     |An integer representing the 4 digit year of the birth date of the person.
+
+#### Parties
+
+|Name          |Type      |Description
+|-----------    |-----------|--------------
+|parties.identification |flexenum |One of "None", "Democratic", "Republican", "Independent", or another free-form string.
+|parties.last_verified_date   |datetime    |A value representing the last verified date of the party registration.
+|parties.active   |boolean     |Whether or not this party registration is active for the affiliated person.
+
+#### Employer Address
+
+|Name          |Type      |Description
+|-----------    |-----------|--------------
+|employer_address.venue	|string	|Optional venue name at the employer address, useful for names of buildings. (ex: Smith Hall)
+|employer_address.address_lines	|strings[]	|An array of strings representing the employer's street address.
+|employer_address.locality	|string	|A city or other local administrative area.
+|employer_address.region	|string	|State or subdivision codes according to ISO 3166-2 (Final 2 alpha digits).
+|employer_address.postal_code	|string	|The region specific postal code, such as a zip code.
+|employer_address.country	|string	|The country code according to ISO 3166-1 Alpha-2.
+|employer_address.language	|string	|Language in which the address is recorded -- language code according to ISO 639.
+|employer_address.location	|object	|An object hash representing the geocoded location information for the address.
+|employer_address.location.latitude	|float	|A positive or negative float number representing the latitude of the address.
+|employer_address.location.longitude	|float	|A positive or negative float number representing the longitude of the address.
+|employer_address.location.accuracy	|enum	|A value representing the accuracy of the geocode. One of "Rooftop" or "Approximate".
+|employer_address.status	|enum	|A value representing the status of the address. One of "Potential", "Verified", or "Bad".
+
+{% include addresses.md %}
+
+#### Profiles
+
+|Name          |Type      |Description
+|-----------    |-----------|--------------
+|profiles.provider       | string |The provider name of the profile. _Example: "Facebook"_
+|profiles.id       | string |The unique identifier provided by the provider for the profile. _Example: "135165"_
+|profiles.url       | string |The URL to the person's web viewable profile. _Example: "http://facebook.com/john.doe"_
+|profiles.handle       | string |The handle name of the profile. Twitter handles should not include the "@" _Example: "johndoe"_
+
+#### Custom Fields
+
+|Name          |Type      |Description
+|-----------    |-----------|--------------
+|custom_fields.[key]	|string	|The key associated with this custom field, with a corresponding value as a string. May be prefixed by servers based on naming conventions they document to control how collisions across systems and data sets occur.
+
+_[Back to top...](#)_
+
+
+### Links
+
+{% include links_intro.md %}
+
+|Name          	|Type		|Description
+|-----------    |-----------|--------------
+|self			|[Person*](people.html)	|A self-referential link to the person.
+|donations		|[Donations[]*](#)  |A link to the collection of donations associated with the person.
+|submissions	|[Submissions[]*](submissions.html)  |A link to the collection of form submissions associated with the person.
+|attendances		|[Attendances[]*](attendances.html)        |A link to the collection of event attendances associated with the person.
+|signatures		|[Signatures[]*](signatures.html)        |A link to the collection of petition signatures associated with the person.
+|outreaches		|[Outreaches[]*](outreaches.html)        |A link to the collection of advocacy campaign outreaches associated with the person.
+|answers		|[Answers[]*](answers.html)  |A link to the collection of answers to questions associated with the person.
+|taggings		|[Taggings[]*](taggings.html)   	|A link to the collection of taggings associated with the person.
+|items		|[Items[]*](items.html)   	|A link to the collection of list items associated with the person.
+|modified_by		|[Person*](people.html)  	|A link to a Person resource representing the last editor of this person.
+|record_canvas_helper |[Record Canvass Helper*](record_canvass.html) | A link to the Record Canvass Helper for this person.
+
+_[Back to top...](#)_
+
+
+## Helpers
+
+{% include helpers_intro.md %}
+
+|Name          |Description
+|-----------    |-----------
+|[person_signup_helper](person_signup.html)      |Allows the creation of a person and associated tag and list membership.
+
+_[Back to top...](#)_
+
+
+## Related Resources
+
+* [Person Signup Helper](person_signup.html)
+* [Donation](#)
+* [Submission](submissions.html)
+* [Attendance](attendances.html)
+* [Signature](signatures.html)
+* [Answer](answers.html)
+* [Tagging](taggings.html)
+* [Item](items.html)
+
+_[Back to top...](#)_
+
+
+## Scenarios
+
+{% include scenarios_intro.md %}
+
+### Scenario: Retrieving a collection of Person resources (GET)
+
+Person resources are sometimes presented as collections of people. For example, calling the people endpoint will return a collection of all the people stored in the system's database associated with your api key.
+
+#### Request
+
+```javascript
+GET https://osdi-sample-system.org/api/v1/people/
+
+Header:
+OSDI-API-Token:[your api key here]
+```
+
+#### Response
+
+```javascript
+200 OK
+
+Content-Type: application/hal+json
+Cache-Control: max-age=0, private, must-revalidate
+
+{
+    "total_pages": 88,
+    "per_page": 25,
+    "page": 1,
+    "total_records": 2188,
+    "_links": {
+        "next": {
+            "href": "https://osdi-sample-system.org/api/v1/people?page=2"
+        },
+        "osdi:people": [
+            {
+                "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3"
+            },
+            {
+                "href": "https://osdi-sample-system.org/api/v1/people/1efc3644-af25-4253-90b8-a0baf12dbd1e"
+            },
+            //(truncated for brevity)
+        ],
+        "curies": [
+            {
+                "name": "osdi",
+                "href": "https://osdi-sample-system.org/docs/v1/{rel}",
+                "templated": true
+            }
+        ],
+        "self": {
+            "href": "https://osdi-sample-system.org/api/v1/people"
+        }
+    },
+    "_embedded": {
+        "osdi:people": [
+            {
+                "identifiers": [
+                    "osdi_sample_system:d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3",
+                    "foreign_system:1"
+                ],
+                "origin_system": "OSDI Sample System",
+                "created_date": "2014-03-20T21:04:31Z",
+                "modified_date": "2014-03-20T21:04:31Z",
+                "given_name": "John",
+                "family_name": "Smith",
+                "honorific_prefix": "Mr.",
+                "honorific_suffix": "Ph.D",
+                "additional_name": "Scott",
+                "gender": "Male",
+                "gender_identity": "Male",
+                "party_identification": "Democratic",
+                "parties": [
+                  {
+                     "identification": "Democratic",
+                     "last_verified_date": "2014-03-20T21:04:31Z",
+                     "active": true
+                  }
+                ],
+                "source": "october_canvass",
+                "browser_url": "http://osdi-sample-system.org/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3",
+                "administrative_url": "http://osdi-sample-system.org/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/manage",
+                "birthdate": {
+                    "month": 6,
+                    "day": 2,
+                    "year": 1973
+                },
+                "ethnicities": [
+                    "African American"
+                ],
+                "languages_spoken": [
+                    "en-US",
+                    "fr-CA"
+                ],
+                "preferred_language": "fr-CA",
+                "employer": "Acme Corp",
+                "employer_address": {
+                    "venue": "Bull Hall",
+                    "address_lines": [
+                        "123 Acme Street",
+                        "Suite 400"
+                    ],
+                    "locality": "New Yorkhaven",
+                    "region": "NY",
+                    "postal_code": "10001",
+                    "country": "US",
+                    "language": "en",
+                    "location": {
+                        "latitude": 38.9382,
+                        "longitude": -77.3349,
+                        "accuracy": "Rooftop"
+                    },
+                    "status": "Verified"
+                },
+                "occupation": "Accountant",
+                "postal_addresses": [
+                    {
+                        "primary": true,
+                        "address_type": "Home",
+                        "address_lines": [
+                            "1900 Pennsylvania Ave"
+                        ],
+                        "locality": "Washington",
+                        "region": "DC",
+                        "postal_code": "20009",
+                        "country": "US",
+                        "language": "en",
+                        "location": {
+                            "latitude": 38.919,
+                            "longitude": -77.0379,
+                            "accuracy": "Rooftop"
+                        },
+                        "last_verified_date": "2014-03-20T21:04:31Z"
+                    }
+                ],
+                "email_addresses": [
+                    {
+                        "primary": true,
+                        "address": "johnsmith@mail.com",
+                        "address_type": "Personal",
+                        "status": "subscribed"
+                    }
+                ],
+                "phone_numbers": [
+                    {
+                        "primary": true,
+                        "number": "11234567890",
+                        "extension": "432",
+                        "description": "Worksite line",
+                        "number_type": "Work",
+                        "operator": "ATT",
+                        "country": "US",
+                        "sms_capable": false,
+                        "do_not_call": true
+                    }
+                ],
+                "profiles": [
+                    {
+                        "provider": "Facebook",
+                        "id": "john.doe.1234",
+                        "url": "https://facebook.com/john.doe"
+                    },
+                    {
+                        "provider": "Twitter",
+                        "id": "eds34d8j2kddfd45",
+                        "url": "https://twitter.com/johndoe",
+                        "handle": "johndoe"
+                    }
+                ],
+                "custom_fields": {
+                    "is_volunteer": "true",
+                    "most_important_issue": "Equal pay",
+                    "union_member": "true"
+                },
+                "_links": {
+                    "self": {
+                        "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3"
+                    },
+                    "osdi:answers": {
+                        "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/answers"
+                    },
+                    "osdi:attendance": {
+                        "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/attendance"
+                    },
+                    "osdi:signatures": {
+                        "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/signatures"
+                    },
+                    "osdi:submissions": {
+                        "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/submissions"
+                    },
+                    "osdi:donations": {
+                        "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/donations"
+                    },
+                    "osdi:outreaches": {
+                        "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/outreaches"
+                    },
+                    "osdi:taggings": {
+                        "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/taggings"
+                    },
+                    "osdi:items": {
+                        "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/items"
+                    },
+                    "osdi:record_canvass_helper": {
+                        "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/record_canvass_helper"
+                    }
+                }
+            },
+            {
+                "given_name": "Jane",
+                "family_name": "Doe",
+                "identifiers": [
+                    "osdi_sample_system:1efc3644-af25-4253-90b8-a0baf12dbd1e"
+                ],
+                "origin_system": "OSDI Sample System",
+                "created_date": "2014-03-20T20:44:13Z",
+                "modified_date": "2014-03-20T20:44:13Z",
+                "browser_url": "http://osdi-sample-system.org/people/1efc3644-af25-4253-90b8-a0baf12dbd1e",
+                "administrative_url": "http://osdi-sample-system.org/people/1efc3644-af25-4253-90b8-a0baf12dbd1e/manage",
+                "email_addresses": [
+                    {
+                        "primary": true,
+                        "address": "janedoe@mail.com",
+                        "status": "unsubscribed"
+                    }
+                ],
+                "postal_addresses": [
+                    {
+                        "primary": true,
+                        "locality": "Washington",
+                        "region": "DC",
+                        "postal_code": "20009",
+                        "country": "US",
+                        "language": "en",
+                        "location": {
+                            "latitude": 38.919,
+                            "longitude": -77.0379,
+                            "accuracy": "Approximate"
+                        }
+                    }
+                ],
+                "_links": {
+                    "self": {
+                        "href": "https://osdi-sample-system.org/api/v1/people/1efc3644-af25-4253-90b8-a0baf12dbd1e"
+                    },
+                    "osdi:answers": {
+                        "href": "https://osdi-sample-system.org/api/v1/people/1efc3644-af25-4253-90b8-a0baf12dbd1e/answers"
+                    },
+                    "osdi:attendance": {
+                        "href": "https://osdi-sample-system.org/api/v1/people/1efc3644-af25-4253-90b8-a0baf12dbd1e/attendance"
+                    },
+                    "osdi:signatures": {
+                        "href": "https://osdi-sample-system.org/api/v1/people/1efc3644-af25-4253-90b8-a0baf12dbd1e/signatures"
+                    },
+                    "osdi:submissions": {
+                        "href": "https://osdi-sample-system.org/api/v1/people/1efc3644-af25-4253-90b8-a0baf12dbd1e/submissions"
+                    },
+                    "osdi:donations": {
+                        "href": "https://osdi-sample-system.org/api/v1/people/1efc3644-af25-4253-90b8-a0baf12dbd1e/donations"
+                    },
+                    "osdi:outreaches": {
+                        "href": "https://osdi-sample-system.org/api/v1/people/1efc3644-af25-4253-90b8-a0baf12dbd1e/outreaches"
+                    },
+                    "osdi:taggings": {
+                        "href": "https://osdi-sample-system.org/api/v1/people/1efc3644-af25-4253-90b8-a0baf12dbd1e/taggings"
+                    },
+                    "osdi:items": {
+                        "href": "https://osdi-sample-system.org/api/v1/people/1efc3644-af25-4253-90b8-a0baf12dbd1e/items"
+                    },
+                    "osdi:record_canvass_helper": {
+                        "href": "https://osdi-sample-system.org/api/v1/people/1efc3644-af25-4253-90b8-a0baf12dbd1e/record_canvass_helper"
+                    }
+                }
+            },
+            //(truncated for brevity)
+        ]
+    }
+}
+```	
+
+_[Back to top...](#)_		
+
+### Scenario: Scenario: Retrieving an individual Person resource (GET)
+
+Calling an individual Person resource will return the resource directly, along with all associated fields and appropriate links to additional information about the person.
+
+#### Request
+
+```javascript
+GET https://osdi-sample-system.org/api/v1/people/d32fcdd6-7366-466d-a3b8-7e0d87c3cd8b
+
+Header:
+OSDI-API-Token:[your api key here]
+```
+
+#### Response
+
+```javascript
+200 OK
+
+Content-Type: application/hal+json
+Cache-Control: max-age=0, private, must-revalidate
+
+{
+    "identifiers": [
+        "osdi_sample_system:d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3",
+        "foreign_system:1"
+    ],
+    "origin_system": "OSDI Sample System",
+    "created_date": "2014-03-20T21:04:31Z",
+    "modified_date": "2014-03-20T21:04:31Z",
+    "given_name": "John",
+    "family_name": "Smith",
+    "honorific_prefix": "Mr.",
+    "honorific_suffix": "Ph.D",
+    "additional_name": "Scott",
+    "gender": "Male",
+    "gender_identity": "Male",
+    "party_identification": "Democratic",
+    "parties": [
+      {
+        "identification": "Democratic",
+        "last_verified_date": "2014-03-20T21:04:31Z",
+        "active": true
+      }
+    ],
+    "source": "october_canvass",
+    "browser_url": "http://osdi-sample-system.org/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3",
+    "administrative_url": "http://osdi-sample-system.org/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/manage",
+    "birthdate": {
+        "month": 6,
+        "day": 2,
+        "year": 1973
+    },
+    "ethnicities": [
+        "African American"
+    ],
+    "languages_spoken": [
+        "en",
+        "fr"
+    ],
+    "employer": "Acme Corp",
+    "employer_address": {
+        "venue": "Bull Hall",
+        "address_lines": [
+            "123 Acme Street",
+            "Suite 400"
+        ],
+        "locality": "New Yorkhaven",
+        "region": "NY",
+        "postal_code": "10001",
+        "country": "US",
+        "language": "en",
+        "location": {
+            "latitude": 38.9382,
+            "longitude": -77.3349,
+            "accuracy": "Rooftop"
+        },
+        "status": "Verified"
+    },
+    "occupation": "Accountant",
+    "postal_addresses": [
+        {
+            "primary": true,
+            "address_type": "Home",
+            "address_lines": [
+                "1900 Pennsylvania Ave"
+            ],
+            "locality": "Washington",
+            "region": "DC",
+            "postal_code": "20009",
+            "country": "US",
+            "language": "en",
+            "location": {
+                "latitude": 38.919,
+                "longitude": -77.0379,
+                "accuracy": "Rooftop"
+            }
+        }
+    ],
+    "email_addresses": [
+        {
+            "primary": true,
+            "address": "johnsmith@mail.com",
+            "address_type": "personal",
+            "status": "subscribed"
+        }
+    ],
+    "phone_numbers": [
+        {
+            "primary": true,
+            "number": "11234567890",
+            "extension": "432",
+            "description": "Worksite line",
+            "number_type": "Work",
+            "operator": "ATT",
+            "country": "US",
+            "sms_capable": false,
+            "do_not_call": true
+        }
+    ],
+    "profiles": [
+        {
+            "provider": "Facebook",
+            "id": "john.doe.1234",
+            "url": "https://facebook.com/john.doe"
+        },
+        {
+            "provider": "Twitter",
+            "id": "eds34d8j2kddfd45",
+            "url": "https://twitter.com/johndoe",
+            "handle": "johndoe"
+        }
+    ],
+    "custom_fields": {
+        "is_volunteer": "true",
+        "most_important_issue": "Equal pay",
+        "union_member": "true"
+    },
+    "_links": {
+        "self": {
+            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3"
+        },
+        "osdi:answers": {
+            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/answers"
+        },
+        "osdi:attendance": {
+            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/attendance"
+        },
+        "osdi:signatures": {
+            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/signatures"
+        },
+        "osdi:submissions": {
+            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/submissions"
+        },
+        "osdi:donations": {
+            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/donations"
+        },
+        "osdi:outreaches": {
+            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/outreaches"
+        },
+        "osdi:taggings": {
+            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/taggings"
+        },
+        "osdi:items": {
+            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/items"
+        },
+        "osdi:record_canvass_helper": {
+            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/record_canvass_helper"
+        }
+    }
+}
+```
+
+_[Back to top...](#)_
+
+
+### Scenario: Creating a new person (POST)
+
+Posting to the people collection endpoint will allow you to create a new person. The response is the new person that was created. While each implementing system will require different fields, any optional fields not included in a post operation should not be set at all by the receiving system, or should be set to default values.
+
+For information on how to link a person with tags and list subscription information in one post, see the [Person Signup Helper](person_signup.html) documentation.
+
+#### Request
+
+```javascript
+POST https://osdi-sample-system.org/api/v1/people/
+
+Header:
+OSDI-API-Token:[your api key here]
+
+{
+    "identifiers": [
+        "foreign_system:1"
+    ],
+    "family_name": "Edwin",
+    "given_name": "Labadie",
+    "additional_name": "Marques",
+    "origin_system": "OpenSupporter",
+    "email_addresses": [
+        {
+            "address":"test-3@example.com",
+            "primary": true,
+            "address_type": "personal",
+            "status": "subscribed"
+        }
+    ],
+    "postal_addresses": [
+        {
+            "primary": true,
+            "address_lines": [
+                "935 Ed Lock"
+            ],
+            "locality": "New Dudley",
+            "region": "MN",
+            "postal_code": "17678",
+            "country": "RU",
+            "address_type": "Home",
+            "status": "Verified"
+        }
+    ],
+    "phone_numbers": [
+        {
+            "primary": true,
+            "number": 19876543210,
+            "number_type": "Mobile",
+            "sms_capable": true
+        }
+    ],
+    "gender": "Male"
+}
+```
+
+#### Response
+
+```javascript
+200 OK
+
+Content-Type: application/hal+json
+Cache-Control: max-age=0, private, must-revalidate
+
+{
+    "identifiers": [
+        "osdi_sample_system:d91b4b2e-ae0e-4cd3-9ed7-de9uemdse",
+        "foreign_system:1"
+    ],
+    "created_date": "2014-03-20T21:04:31Z",
+    "modified_date": "2014-03-20T21:04:31Z",
+    "family_name": "Edwin",
+    "given_name": "Labadie",
+    "additional_name": "Marques",
+    "origin_system": "OpenSupporter",
+    "browser_url": "http://osdi-sample-system.org/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3",
+    "administrative_url": "http://osdi-sample-system.org/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/manage",
+    "email_addresses": [
+        {
+            "address":"test-3@example.com",
+            "primary": true,
+            "address_type": "personal",
+            "status": "subscribed"
+        }
+    ],
+    "postal_addresses": [
+        {
+            "primary": true,
+            "address_lines": [
+                "935 Ed Lock"
+            ],
+            "locality": "New Dudley",
+            "region": "MN",
+            "postal_code": "17678",
+            "country": "RU",
+            "address_type": "Home",
+            "status": "Verified"
+        }
+    ],
+    "phone_numbers": [
+        {
+            "primary": true,
+            "number": 19876543210,
+            "number_type": "Mobile",
+            "sms_capable": true
+        }
+    ],
+    "gender": "Male",
+    "_links": {
+        "self": {
+            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse"
+        },
+        "osdi:answers": {
+            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/answers"
+        },
+        "osdi:attendance": {
+            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/attendance"
+        },
+        "osdi:signatures": {
+            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/signatures"
+        },
+        "osdi:submissions": {
+            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/submissions"
+        },
+        "osdi:donations": {
+            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/donations"
+        },
+        "osdi:outreaches": {
+            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/outreaches"
+        },
+        "osdi:taggings": {
+            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/taggings"
+        },
+        "osdi:items": {
+            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/items"
+        },
+        "osdi:record_canvass_helper": {
+            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/record_canvass_helper"
+        }
+    }
+}
+```
+
+_[Back to top...](#)_
+
+
+### Scenario: Modifying a person (PUT)
+
+You can update a person by calling a PUT operation on that person's endpoint. Your PUT should contain fields that you want to update. Missing fields will be ignored by the receiving system. Systems may also ignore PUT values, depending on whether fields you are trying to modify are read-only or not. You may set an attribute to nil by including the attribute using `nil` for value.
+
+{% include array_warning.md %}
+
+#### Request
+
+```javascript
+PUT https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse
+
+Header:
+OSDI-API-Token:[your api key here]
+
+{
+    "family_name": "Ed",
+    "email_addresses": [
+        {
+            "address":"test-new@example.com",
+            "primary": true,
+            "address_type": "personal"
+        }
+    ]
+}
+
+```
+
+#### Response
+```javascript
+200 OK
+
+Content-Type: application/hal+json
+Cache-Control: max-age=0, private, must-revalidate
+
+{
+    "identifiers": [
+        "osdi_sample_system:d91b4b2e-ae0e-4cd3-9ed7-de9uemdse",
+        "foreign_system:1"
+    ],
+    "created_date": "2014-03-20T21:04:31Z",
+    "modified_date": "2014-03-20T22:04:31Z",
+    "family_name": "Ed",
+    "given_name": "Labadie",
+    "additional_name": "Marques",
+    "origin_system": "OpenSupporter",
+    "browser_url": "http://osdi-sample-system.org/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3",
+    "administrative_url": "http://osdi-sample-system.org/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/manage",
+    "email_addresses": [
+        {
+            "address":"test-new@example.com",
+            "primary": true,
+            "address_type": "personal",
+            "status": "subscribed"
+        }
+    ],
+    "postal_addresses": [
+        {
+            "primary": true,
+            "address_lines": [
+                "935 Ed Lock"
+            ],
+            "locality": "New Dudley",
+            "region": "MN",
+            "postal_code": "17678",
+            "country": "RU",
+            "address_type": "Home",
+            "status": "Verified"
+        }
+    ],
+    "phone_numbers": [
+        {
+            "primary": true,
+            "number": 19876543210,
+            "number_type": "Mobile",
+            "sms_capable": true
+        }
+    ],
+    "gender": "Male",
+    "_links": {
+        "self": {
+            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse"
+        },
+        "osdi:answers": {
+            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/answers"
+        },
+        "osdi:attendance": {
+            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/attendance"
+        },
+        "osdi:signatures": {
+            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/signatures"
+        },
+        "osdi:submissions": {
+            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/submissions"
+        },
+        "osdi:donations": {
+            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/donations"
+        },
+        "osdi:outreaches": {
+            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/outreaches"
+        },
+        "osdi:taggings": {
+            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/taggings"
+        },
+        "osdi:items": {
+            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/items"
+        },
+        "osdi:record_canvass_helper": {
+            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/record_canvass_helper"
+        }
+    }
+}
+```
+
+_[Back to top...](#)_
+
+
+### Scenario: Deleting a person (DELETE)
+
+You may delete a person by calling the DELETE command on the person's endpoint.
+
+#### Request
+
+```javascript
+DELETE https://osdi-sample-system.org/api/v1/people/d32fcdd6-7366-466d-a3b8-7e0d87c3cd8b
+
+Header:
+OSDI-API-Token:[your api key here]
+```
+
+#### Response
+
+```javascript
+200 OK
+
+Content-Type: application/hal+json
+Cache-Control: max-age=0, private, must-revalidate
+
+{
+    "notice": "This person was successfully deleted."
+}
+```
+
+_[Back to top...](#)_

--- a/organizations.md
+++ b/organizations.md
@@ -3,7 +3,8 @@ layout: default
 title: Organization
 ---
 
-# Organization
+# Organization (experimental)
+Experimental areas of the specification are published to illustrate the design direction, allow implementers to prototype, while taking additional feedback.
 
 This document defines the Organization resource.
 

--- a/organizations.md
+++ b/organizations.md
@@ -215,14 +215,17 @@ Cache-Control: max-age=0, private, must-revalidate
                 "origin_system": "OSDI Sample System",
                 "created_date": "2014-03-20T21:04:31Z",
                 "modified_date": "2014-03-20T21:04:31Z",
-                "given_name": "John",
+                "organization": "F.O.O.",
+                "legal_status": "c3",
+                "summary": "For Our Opinions - helping people who have opinions everywhere",
+                "site_url": "https://foo.example/",
+                "logo_image_url": "https://foo.example/images/200x200/logo.png",
                 "source": "october_canvass",
                 "browser_url": "http://osdi-sample-system.org/organizations/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3",
                 "administrative_url": "http://osdi-sample-system.org/organizations/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/manage",
                 "postal_addresses": [
                     {
                         "primary": true,
-                        "address_type": "Home",
                         "address_lines": [
                             "1900 Pennsylvania Ave"
                         ],
@@ -242,8 +245,7 @@ Cache-Control: max-age=0, private, must-revalidate
                 "email_addresses": [
                     {
                         "primary": true,
-                        "address": "johnsmith@mail.com",
-                        "address_type": "Personal",
+                        "address": "help@mail.com",
                         "status": "subscribed"
                     }
                 ],
@@ -307,7 +309,9 @@ Cache-Control: max-age=0, private, must-revalidate
                 }
             },
             {
-                "given_name": "Jane",
+                "organization": "Bars For Justice",
+                "legal_status": "c4",
+                "logo_image_url": "https://bar.example/images/logo.svg",
                 "identifiers": [
                     "osdi_sample_system:1efc3644-af25-4253-90b8-a0baf12dbd1e"
                 ],
@@ -319,7 +323,7 @@ Cache-Control: max-age=0, private, must-revalidate
                 "email_addresses": [
                     {
                         "primary": true,
-                        "address": "janedoe@mail.com",
+                        "address": "support@mail.com",
                         "status": "unsubscribed"
                     }
                 ],
@@ -405,14 +409,17 @@ Cache-Control: max-age=0, private, must-revalidate
     "origin_system": "OSDI Sample System",
     "created_date": "2014-03-20T21:04:31Z",
     "modified_date": "2014-03-20T21:04:31Z",
-    "given_name": "John",
+    "organization": "F.O.O.",
+    "legal_status": "c3",
+    "summary": "For Our Opinions - helping people who have opinions everywhere",
+    "site_url": "https://foo.example/",
+    "logo_image_url": "https://foo.example/images/200x200/logo.png",
     "source": "october_canvass",
     "browser_url": "http://osdi-sample-system.org/organizations/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3",
     "administrative_url": "http://osdi-sample-system.org/organizations/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/manage",
     "postal_addresses": [
         {
             "primary": true,
-            "address_type": "Home",
             "address_lines": [
                 "1900 Pennsylvania Ave"
             ],
@@ -431,8 +438,7 @@ Cache-Control: max-age=0, private, must-revalidate
     "email_addresses": [
         {
             "primary": true,
-            "address": "johnsmith@mail.com",
-            "address_type": "personal",
+            "address": "help@mail.com",
             "status": "subscribed"
         }
     ],
@@ -516,13 +522,12 @@ OSDI-API-Token:[your api key here]
     "identifiers": [
         "foreign_system:1"
     ],
-    "given_name": "Labadie",
+    "organization": "Labadabadoo",
     "origin_system": "OpenSupporter",
     "email_addresses": [
         {
             "address":"test-3@example.com",
             "primary": true,
-            "address_type": "personal",
             "status": "subscribed"
         }
     ],
@@ -536,7 +541,6 @@ OSDI-API-Token:[your api key here]
             "region": "MN",
             "postal_code": "17678",
             "country": "RU",
-            "address_type": "Home",
             "status": "Verified"
         }
     ],
@@ -566,7 +570,7 @@ Cache-Control: max-age=0, private, must-revalidate
     ],
     "created_date": "2014-03-20T21:04:31Z",
     "modified_date": "2014-03-20T21:04:31Z",
-    "given_name": "Labadie",
+    "organization": "Labadabadoo",
     "origin_system": "OpenSupporter",
     "browser_url": "http://osdi-sample-system.org/organizations/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3",
     "administrative_url": "http://osdi-sample-system.org/organizations/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/manage",
@@ -574,7 +578,6 @@ Cache-Control: max-age=0, private, must-revalidate
         {
             "address":"test-3@example.com",
             "primary": true,
-            "address_type": "personal",
             "status": "subscribed"
         }
     ],
@@ -588,7 +591,6 @@ Cache-Control: max-age=0, private, must-revalidate
             "region": "MN",
             "postal_code": "17678",
             "country": "RU",
-            "address_type": "Home",
             "status": "Verified"
         }
     ],
@@ -650,12 +652,11 @@ Header:
 OSDI-API-Token:[your api key here]
 
 {
-    "given_name": "Ed",
+    "organization": "Doctors for Education",
     "email_addresses": [
         {
             "address":"test-new@example.com",
-            "primary": true,
-            "address_type": "personal"
+            "primary": true
         }
     ]
 }
@@ -676,7 +677,7 @@ Cache-Control: max-age=0, private, must-revalidate
     ],
     "created_date": "2014-03-20T21:04:31Z",
     "modified_date": "2014-03-20T22:04:31Z",
-    "given_name": "Labadie",
+    "organization": "Labadabadoo",
     "origin_system": "OpenSupporter",
     "browser_url": "http://osdi-sample-system.org/organizations/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3",
     "administrative_url": "http://osdi-sample-system.org/organizations/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/manage",
@@ -684,7 +685,6 @@ Cache-Control: max-age=0, private, must-revalidate
         {
             "address":"test-new@example.com",
             "primary": true,
-            "address_type": "personal",
             "status": "subscribed"
         }
     ],
@@ -698,7 +698,6 @@ Cache-Control: max-age=0, private, must-revalidate
             "region": "MN",
             "postal_code": "17678",
             "country": "RU",
-            "address_type": "Home",
             "status": "Verified"
         }
     ],

--- a/organizations.md
+++ b/organizations.md
@@ -1,15 +1,18 @@
 ---
 layout: default
-title: Person
+title: Organization
 ---
 
-# Person
+# Organization
 
-This document defines the Person resource. 
+This document defines the Organization resource.
 
-People are individual users who are stored in the OSDI system's database in some way.
+Organizations are political/legal entities that generally organize a group of people that are stored in the OSDI system's database in some way.
 
-People have names, email addresses, and other information, and they have associated action histories recording the actions they've taken on the system, such as a list of their signatures on various petitions.
+The Organization resource is as similar as possible to the [Person*](people.html) resource, removing some
+fields that only apply to people (e.g. family name, gender identity, etc) and adding others like
+legal status and logo. However, the similarities are much greater. Organizations have email and postal addresses,
+facebook and twitter pages, etc.  Many systems will store Organizations and People in the same database table and separate them by a type field or otherwise.
 
 
 ### Sections:
@@ -17,7 +20,8 @@ People have names, email addresses, and other information, and they have associa
 * [Endpoints and URL structures](#endpoints-and-url-structures)
 * [Fields](#fields)
     * [Common Fields](#common-fields)
-    * [People Fields](#people-fields)
+    * [Organization Fields](#organization-fields)
+    * [Common to Person Fields](#common-to-person-fields)
     * [Related Objects](#related-objects)
     * [Links](#links)
 * [Helpers](#helpers)
@@ -32,7 +36,7 @@ People have names, email addresses, and other information, and they have associa
 
 {% include endpoints_and_url_structures.md %}
 
-The link relation label for a Person resource is ```osdi:person``` for a single Person resource or ```osdi:people``` for a collection of Person resources.
+The link relation label for a Person resource is ```osdi:organization``` for a single Organization resource or ```osdi:organizations``` for a collection of Organization resources.
 
 _[Back to top...](#)_
 
@@ -46,35 +50,41 @@ _[Back to top...](#)_
 _[Back to top...](#)_
 
 
-### People Fields
+### Organization Fields
 
-A list of fields specific to the Person resource.
+A list of fields specific to the Organization resource.  A few things are
+purposefully distinct from Person and other objects.  For instance,
+`organization` for the organization's name is unique so an organization
+resource is easily distinguishable from other resource types.
 
 |Name          |Type      |Description
 |-----------    |-----------|--------------
-|family_name      |string     |The person's last name.
-|given_name     |string     |The person's first name.
-|additional_name    |string     |An additional name not included in family or given. Usually a middle name.
-|honorific_prefix           |string    |An honorific prefix like "Dr", "Mr", etc...
-|honorific_suffix           |string    |An honorific suffix like "Jr.", "Ph.D", etc...
-|gender         |enum     |The gender binary with which a person most closely identifies, or "Other" if the person identifies with neither. One of "Female", "Male", or "Other".
-|gender_identity|string     |The self-described gender with which a person identifies. While this field is free-form, data should still follow standardized forms whenever possible (i.e. use "Female" and not "female" or "F"). _Examples: If a person self-identifies as "Female", both_ `gender` _and_ `gender_identity` _fields should have a value of "Female". If a person self-identifies as "Transgender Female",_ `gender` _should have a value of "Female" and_ `gender_identity` _should have a value of "Transgender Female"._
-|party_identification   |flexenum     |Flexenum describing the person's politcal party identification. One of "None", "Democratic", "Republican", "Independent", or another free-form string.
-|parties |[Parties[]](#parties)|An array of all party object hashes associated with the person (past and present).
-|source         |string     |Information about the source where this person record was acquired.   _Example: "facebook-ad-october"_
-|ethnicities|strings[]   |A unique string array representing a person's ethnicities.
-|languages_spoken|strings[]      | Unique string array of RFC5646 tags representing the languages spoken by the person. Example: en,  en-US, fr-CA, pt-BR
-|preferred_language | string  | The RFC5646 tag representing the person's preferred language.
-|browser_url		|string		|A URL string pointing to the publicly available person page on the web, such as a public profile page.
-|administrative_url		|string		|A URL string pointing to the person's administrative page on the web, such as a page for managing this person's record.
-|birthdate	|[Birthdate](#birthdate)    |An object hash representing the birthdate of the person.
-|employer|string    |The name of the person's employer.
-|employer_address|[Employer Address](#employer-address)    |An object hash representing the postal address of the person's employer.
-|postal_addresses      |[Postal Addresses[]](#postal-addresses)   |An array of postal address object hashes associated with the person.
-|email_addresses	|[Email Addresses[]](#email-addresses)   |An array of email address object hashes associated with the person.
-|phone_numbers	|[Phone Numbers[]](#phone-numbers)   |An array of phone number object hashes associated with the person.
-|profiles       | [Profiles[]](#profiles) |An array of profile object hashes for online services related to the person.
-|custom_fields	|[Custom Fields](#custom-fields)	|An object hash of key/value pairs associated with the person created by a user rather than a service or vendor.
+|organization  |string     |The organization's human-readable common name. This may not be a full name, if the organization, for instance mostly goes by an acronym -- it should be the value that would be in a listing for the organization and in prose.
+|legal_status  |flexenum   |The organization's legal status, or "unofficial" if the organization does not have a corresponding legal entity.  Common values will be "llc", "sole prop", "c3", "c4", and "pac".
+|logo_image_url|string     |A URL string pointing to a publicly available image file of the organization's logo. It should be a format supported in the `&lt;img>` html tag.
+|site_url      |string     |A URL pointing to the organization's own public homepage.  Whereas `browser_url` (below) may be to a local page contextual to the system, site_url should always be the organization's own site.
+|summary       |string     |A short one-line description of the organization. If the `organization` key contains an acronym, this would be where you include the full name.
+|description   |string     |A longer description of the organization, possibly contextual to the origin_system the record comes from.
+
+_[Back to top...](#)_
+
+
+### Common to Person Fields
+
+A list of fields common to the Person resource. These fields are preserved in both so processing data can largely be the same for each.  Some of these fields have different connotations in the Organization resource.  For instance party_identification and languages_spoken are more about the official support/affiliation from the organization rather than about the total or average of all the organization's members.
+
+|Name          |Type      |Description
+|-----------    |-----------|--------------
+|party_identification   |flexenum     |Flexenum describing the organization's politcal party identification. One of "None", "Democratic", "Republican", etc. Note that this is not about the organization's political 'tilt' but only if it has direct association with the political party
+|source         |string     |Information about the source where this organization record was acquired.   _Example: "facebook-ad-october"_
+|languages_spoken|strings[]      | Unique string array of RFC5646 tags representing the languages spoken by the organization. Example: en,  en-US, fr-CA, pt-BR
+|browser_url		|string		|A URL string pointing to the publicly available organization page on the web, such as a public profile page.
+|administrative_url		|string		|A URL string pointing to the organization's administrative page on the web, such as a page for managing this organization's record.
+|postal_addresses      |[Postal Addresses[]](#postal-addresses)   |An array of postal address object hashes associated with the organization.
+|email_addresses	|[Email Addresses[]](#email-addresses)   |An array of email address object hashes associated with the organization.
+|phone_numbers	|[Phone Numbers[]](#phone-numbers)   |An array of phone number object hashes associated with the organization.
+|profiles       | [Profiles[]](#profiles) |An array of profile object hashes for online services related to the organization.
+|custom_fields	|[Custom Fields](#custom-fields)	|An object hash of key/value pairs associated with the organization created by a user rather than a service or vendor.
 
 _[Back to top...](#)_
 
@@ -82,39 +92,6 @@ _[Back to top...](#)_
 ### Related Objects
 
 These JSON hashes included in the table above are broken out into their own tables for readability, rather than independent resources with their own endpoints.
-
-#### Birthdate
-
-|Name          |Type      |Description
-|-----------    |-----------|--------------
-|birthdate.month|integer    |An integer representing the month of the birth date of the person.
-|birthdate.day  |integer    |An integer representing the day of the birth date of the person.
-|birthdate.year|integer     |An integer representing the 4 digit year of the birth date of the person.
-
-#### Parties
-
-|Name          |Type      |Description
-|-----------    |-----------|--------------
-|parties.identification |flexenum |One of "None", "Democratic", "Republican", "Independent", or another free-form string.
-|parties.last_verified_date   |datetime    |A value representing the last verified date of the party registration.
-|parties.active   |boolean     |Whether or not this party registration is active for the affiliated person.
-
-#### Employer Address
-
-|Name          |Type      |Description
-|-----------    |-----------|--------------
-|employer_address.venue	|string	|Optional venue name at the employer address, useful for names of buildings. (ex: Smith Hall)
-|employer_address.address_lines	|strings[]	|An array of strings representing the employer's street address.
-|employer_address.locality	|string	|A city or other local administrative area.
-|employer_address.region	|string	|State or subdivision codes according to ISO 3166-2 (Final 2 alpha digits).
-|employer_address.postal_code	|string	|The region specific postal code, such as a zip code.
-|employer_address.country	|string	|The country code according to ISO 3166-1 Alpha-2.
-|employer_address.language	|string	|Language in which the address is recorded -- language code according to ISO 639.
-|employer_address.location	|object	|An object hash representing the geocoded location information for the address.
-|employer_address.location.latitude	|float	|A positive or negative float number representing the latitude of the address.
-|employer_address.location.longitude	|float	|A positive or negative float number representing the longitude of the address.
-|employer_address.location.accuracy	|enum	|A value representing the accuracy of the geocode. One of "Rooftop" or "Approximate".
-|employer_address.status	|enum	|A value representing the status of the address. One of "Potential", "Verified", or "Bad".
 
 {% include addresses.md %}
 
@@ -124,7 +101,7 @@ These JSON hashes included in the table above are broken out into their own tabl
 |-----------    |-----------|--------------
 |profiles.provider       | string |The provider name of the profile. _Example: "Facebook"_
 |profiles.id       | string |The unique identifier provided by the provider for the profile. _Example: "135165"_
-|profiles.url       | string |The URL to the person's web viewable profile. _Example: "http://facebook.com/john.doe"_
+|profiles.url       | string |The URL to the organization's web viewable profile. _Example: "http://facebook.com/john.doe"_
 |profiles.handle       | string |The handle name of the profile. Twitter handles should not include the "@" _Example: "johndoe"_
 
 #### Custom Fields
@@ -142,35 +119,27 @@ _[Back to top...](#)_
 
 |Name          	|Type		|Description
 |-----------    |-----------|--------------
-|self			|[Person*](people.html)	|A self-referential link to the person.
-|donations		|[Donations[]*](#)  |A link to the collection of donations associated with the person.
-|submissions	|[Submissions[]*](submissions.html)  |A link to the collection of form submissions associated with the person.
-|attendances		|[Attendances[]*](attendances.html)        |A link to the collection of event attendances associated with the person.
-|signatures		|[Signatures[]*](signatures.html)        |A link to the collection of petition signatures associated with the person.
-|outreaches		|[Outreaches[]*](outreaches.html)        |A link to the collection of advocacy campaign outreaches associated with the person.
-|answers		|[Answers[]*](answers.html)  |A link to the collection of answers to questions associated with the person.
-|taggings		|[Taggings[]*](taggings.html)   	|A link to the collection of taggings associated with the person.
-|items		|[Items[]*](items.html)   	|A link to the collection of list items associated with the person.
-|modified_by		|[Person*](people.html)  	|A link to a Person resource representing the last editor of this person.
-|record_canvas_helper |[Record Canvass Helper*](record_canvass.html) | A link to the Record Canvass Helper for this person.
+|self			|[Organization*](organizations.html)	|A self-referential link to the organization.
+|events		|[Events[]*](#)  |A link to the collection of events the organization has sponsored.
+|petitions		|[Petitions[]*](#)  |A link to the collection of petitions the organization has sponsored.
+|donations		|[Donations[]*](#)  |A link to the collection of donations associated with the organization.
+|submissions	|[Submissions[]*](submissions.html)  |A link to the collection of form submissions associated with the organization.
+|attendances		|[Attendances[]*](attendances.html)        |A link to the collection of event attendances associated with the organization.
+|signatures		|[Signatures[]*](signatures.html)        |A link to the collection of petition signatures associated with the organization.
+|outreaches		|[Outreaches[]*](outreaches.html)        |A link to the collection of advocacy campaign outreaches associated with the organization.
+|answers		|[Answers[]*](answers.html)  |A link to the collection of answers to questions associated with the organization.
+|taggings		|[Taggings[]*](taggings.html)   	|A link to the collection of taggings associated with the organization.
+|items		|[Items[]*](items.html)   	|A link to the collection of list items associated with the organization.
+|modified_by		|[Person*](people.html)  	|A link to a Person resource representing the last editor of this organization record.
 
-_[Back to top...](#)_
-
-
-## Helpers
-
-{% include helpers_intro.md %}
-
-|Name          |Description
-|-----------    |-----------
-|[person_signup_helper](person_signup.html)      |Allows the creation of a person and associated tag and list membership.
 
 _[Back to top...](#)_
 
 
 ## Related Resources
 
-* [Person Signup Helper](person_signup.html)
+* [Petition](#)
+* [Event](#)
 * [Donation](#)
 * [Submission](submissions.html)
 * [Attendance](attendances.html)
@@ -186,14 +155,14 @@ _[Back to top...](#)_
 
 {% include scenarios_intro.md %}
 
-### Scenario: Retrieving a collection of Person resources (GET)
+### Scenario: Retrieving a collection of Organization resources (GET)
 
-Person resources are sometimes presented as collections of people. For example, calling the people endpoint will return a collection of all the people stored in the system's database associated with your api key.
+Organization resources are sometimes presented as collections of organizations. For example, calling the organizations endpoint will return a collection of all the organizations stored in the system's database associated with your api key.
 
 #### Request
 
 ```javascript
-GET https://osdi-sample-system.org/api/v1/people/
+GET https://osdi-sample-system.org/api/v1/organizations/
 
 Header:
 OSDI-API-Token:[your api key here]
@@ -214,14 +183,14 @@ Cache-Control: max-age=0, private, must-revalidate
     "total_records": 2188,
     "_links": {
         "next": {
-            "href": "https://osdi-sample-system.org/api/v1/people?page=2"
+            "href": "https://osdi-sample-system.org/api/v1/organizations?page=2"
         },
-        "osdi:people": [
+        "osdi:organizations": [
             {
-                "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3"
+                "href": "https://osdi-sample-system.org/api/v1/organizations/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3"
             },
             {
-                "href": "https://osdi-sample-system.org/api/v1/people/1efc3644-af25-4253-90b8-a0baf12dbd1e"
+                "href": "https://osdi-sample-system.org/api/v1/organizations/1efc3644-af25-4253-90b8-a0baf12dbd1e"
             },
             //(truncated for brevity)
         ],
@@ -233,11 +202,11 @@ Cache-Control: max-age=0, private, must-revalidate
             }
         ],
         "self": {
-            "href": "https://osdi-sample-system.org/api/v1/people"
+            "href": "https://osdi-sample-system.org/api/v1/organizations"
         }
     },
     "_embedded": {
-        "osdi:people": [
+        "osdi:organizations": [
             {
                 "identifiers": [
                     "osdi_sample_system:d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3",
@@ -247,56 +216,9 @@ Cache-Control: max-age=0, private, must-revalidate
                 "created_date": "2014-03-20T21:04:31Z",
                 "modified_date": "2014-03-20T21:04:31Z",
                 "given_name": "John",
-                "family_name": "Smith",
-                "honorific_prefix": "Mr.",
-                "honorific_suffix": "Ph.D",
-                "additional_name": "Scott",
-                "gender": "Male",
-                "gender_identity": "Male",
-                "party_identification": "Democratic",
-                "parties": [
-                  {
-                     "identification": "Democratic",
-                     "last_verified_date": "2014-03-20T21:04:31Z",
-                     "active": true
-                  }
-                ],
                 "source": "october_canvass",
-                "browser_url": "http://osdi-sample-system.org/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3",
-                "administrative_url": "http://osdi-sample-system.org/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/manage",
-                "birthdate": {
-                    "month": 6,
-                    "day": 2,
-                    "year": 1973
-                },
-                "ethnicities": [
-                    "African American"
-                ],
-                "languages_spoken": [
-                    "en-US",
-                    "fr-CA"
-                ],
-                "preferred_language": "fr-CA",
-                "employer": "Acme Corp",
-                "employer_address": {
-                    "venue": "Bull Hall",
-                    "address_lines": [
-                        "123 Acme Street",
-                        "Suite 400"
-                    ],
-                    "locality": "New Yorkhaven",
-                    "region": "NY",
-                    "postal_code": "10001",
-                    "country": "US",
-                    "language": "en",
-                    "location": {
-                        "latitude": 38.9382,
-                        "longitude": -77.3349,
-                        "accuracy": "Rooftop"
-                    },
-                    "status": "Verified"
-                },
-                "occupation": "Accountant",
+                "browser_url": "http://osdi-sample-system.org/organizations/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3",
+                "administrative_url": "http://osdi-sample-system.org/organizations/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/manage",
                 "postal_addresses": [
                     {
                         "primary": true,
@@ -352,54 +274,48 @@ Cache-Control: max-age=0, private, must-revalidate
                     }
                 ],
                 "custom_fields": {
-                    "is_volunteer": "true",
-                    "most_important_issue": "Equal pay",
-                    "union_member": "true"
+                    "most_important_issue": "Equal pay"
                 },
                 "_links": {
                     "self": {
-                        "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3"
+                        "href": "https://osdi-sample-system.org/api/v1/organizations/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3"
                     },
                     "osdi:answers": {
-                        "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/answers"
+                        "href": "https://osdi-sample-system.org/api/v1/organizations/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/answers"
                     },
                     "osdi:attendance": {
-                        "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/attendance"
+                        "href": "https://osdi-sample-system.org/api/v1/organizations/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/attendance"
                     },
                     "osdi:signatures": {
-                        "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/signatures"
+                        "href": "https://osdi-sample-system.org/api/v1/organizations/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/signatures"
                     },
                     "osdi:submissions": {
-                        "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/submissions"
+                        "href": "https://osdi-sample-system.org/api/v1/organizations/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/submissions"
                     },
                     "osdi:donations": {
-                        "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/donations"
+                        "href": "https://osdi-sample-system.org/api/v1/organizations/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/donations"
                     },
                     "osdi:outreaches": {
-                        "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/outreaches"
+                        "href": "https://osdi-sample-system.org/api/v1/organizations/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/outreaches"
                     },
                     "osdi:taggings": {
-                        "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/taggings"
+                        "href": "https://osdi-sample-system.org/api/v1/organizations/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/taggings"
                     },
                     "osdi:items": {
-                        "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/items"
-                    },
-                    "osdi:record_canvass_helper": {
-                        "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/record_canvass_helper"
+                        "href": "https://osdi-sample-system.org/api/v1/organizations/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/items"
                     }
                 }
             },
             {
                 "given_name": "Jane",
-                "family_name": "Doe",
                 "identifiers": [
                     "osdi_sample_system:1efc3644-af25-4253-90b8-a0baf12dbd1e"
                 ],
                 "origin_system": "OSDI Sample System",
                 "created_date": "2014-03-20T20:44:13Z",
                 "modified_date": "2014-03-20T20:44:13Z",
-                "browser_url": "http://osdi-sample-system.org/people/1efc3644-af25-4253-90b8-a0baf12dbd1e",
-                "administrative_url": "http://osdi-sample-system.org/people/1efc3644-af25-4253-90b8-a0baf12dbd1e/manage",
+                "browser_url": "http://osdi-sample-system.org/organizations/1efc3644-af25-4253-90b8-a0baf12dbd1e",
+                "administrative_url": "http://osdi-sample-system.org/organizations/1efc3644-af25-4253-90b8-a0baf12dbd1e/manage",
                 "email_addresses": [
                     {
                         "primary": true,
@@ -424,34 +340,31 @@ Cache-Control: max-age=0, private, must-revalidate
                 ],
                 "_links": {
                     "self": {
-                        "href": "https://osdi-sample-system.org/api/v1/people/1efc3644-af25-4253-90b8-a0baf12dbd1e"
+                        "href": "https://osdi-sample-system.org/api/v1/organizations/1efc3644-af25-4253-90b8-a0baf12dbd1e"
                     },
                     "osdi:answers": {
-                        "href": "https://osdi-sample-system.org/api/v1/people/1efc3644-af25-4253-90b8-a0baf12dbd1e/answers"
+                        "href": "https://osdi-sample-system.org/api/v1/organizations/1efc3644-af25-4253-90b8-a0baf12dbd1e/answers"
                     },
                     "osdi:attendance": {
-                        "href": "https://osdi-sample-system.org/api/v1/people/1efc3644-af25-4253-90b8-a0baf12dbd1e/attendance"
+                        "href": "https://osdi-sample-system.org/api/v1/organizations/1efc3644-af25-4253-90b8-a0baf12dbd1e/attendance"
                     },
                     "osdi:signatures": {
-                        "href": "https://osdi-sample-system.org/api/v1/people/1efc3644-af25-4253-90b8-a0baf12dbd1e/signatures"
+                        "href": "https://osdi-sample-system.org/api/v1/organizations/1efc3644-af25-4253-90b8-a0baf12dbd1e/signatures"
                     },
                     "osdi:submissions": {
-                        "href": "https://osdi-sample-system.org/api/v1/people/1efc3644-af25-4253-90b8-a0baf12dbd1e/submissions"
+                        "href": "https://osdi-sample-system.org/api/v1/organizations/1efc3644-af25-4253-90b8-a0baf12dbd1e/submissions"
                     },
                     "osdi:donations": {
-                        "href": "https://osdi-sample-system.org/api/v1/people/1efc3644-af25-4253-90b8-a0baf12dbd1e/donations"
+                        "href": "https://osdi-sample-system.org/api/v1/organizations/1efc3644-af25-4253-90b8-a0baf12dbd1e/donations"
                     },
                     "osdi:outreaches": {
-                        "href": "https://osdi-sample-system.org/api/v1/people/1efc3644-af25-4253-90b8-a0baf12dbd1e/outreaches"
+                        "href": "https://osdi-sample-system.org/api/v1/organizations/1efc3644-af25-4253-90b8-a0baf12dbd1e/outreaches"
                     },
                     "osdi:taggings": {
-                        "href": "https://osdi-sample-system.org/api/v1/people/1efc3644-af25-4253-90b8-a0baf12dbd1e/taggings"
+                        "href": "https://osdi-sample-system.org/api/v1/organizations/1efc3644-af25-4253-90b8-a0baf12dbd1e/taggings"
                     },
                     "osdi:items": {
-                        "href": "https://osdi-sample-system.org/api/v1/people/1efc3644-af25-4253-90b8-a0baf12dbd1e/items"
-                    },
-                    "osdi:record_canvass_helper": {
-                        "href": "https://osdi-sample-system.org/api/v1/people/1efc3644-af25-4253-90b8-a0baf12dbd1e/record_canvass_helper"
+                        "href": "https://osdi-sample-system.org/api/v1/organizations/1efc3644-af25-4253-90b8-a0baf12dbd1e/items"
                     }
                 }
             },
@@ -463,14 +376,14 @@ Cache-Control: max-age=0, private, must-revalidate
 
 _[Back to top...](#)_		
 
-### Scenario: Scenario: Retrieving an individual Person resource (GET)
+### Scenario: Scenario: Retrieving an individual Organization resource (GET)
 
-Calling an individual Person resource will return the resource directly, along with all associated fields and appropriate links to additional information about the person.
+Calling an individual Organization resource will return the resource directly, along with all associated fields and appropriate links to additional information about the organization.
 
 #### Request
 
 ```javascript
-GET https://osdi-sample-system.org/api/v1/people/d32fcdd6-7366-466d-a3b8-7e0d87c3cd8b
+GET https://osdi-sample-system.org/api/v1/organizations/d32fcdd6-7366-466d-a3b8-7e0d87c3cd8b
 
 Header:
 OSDI-API-Token:[your api key here]
@@ -493,55 +406,9 @@ Cache-Control: max-age=0, private, must-revalidate
     "created_date": "2014-03-20T21:04:31Z",
     "modified_date": "2014-03-20T21:04:31Z",
     "given_name": "John",
-    "family_name": "Smith",
-    "honorific_prefix": "Mr.",
-    "honorific_suffix": "Ph.D",
-    "additional_name": "Scott",
-    "gender": "Male",
-    "gender_identity": "Male",
-    "party_identification": "Democratic",
-    "parties": [
-      {
-        "identification": "Democratic",
-        "last_verified_date": "2014-03-20T21:04:31Z",
-        "active": true
-      }
-    ],
     "source": "october_canvass",
-    "browser_url": "http://osdi-sample-system.org/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3",
-    "administrative_url": "http://osdi-sample-system.org/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/manage",
-    "birthdate": {
-        "month": 6,
-        "day": 2,
-        "year": 1973
-    },
-    "ethnicities": [
-        "African American"
-    ],
-    "languages_spoken": [
-        "en",
-        "fr"
-    ],
-    "employer": "Acme Corp",
-    "employer_address": {
-        "venue": "Bull Hall",
-        "address_lines": [
-            "123 Acme Street",
-            "Suite 400"
-        ],
-        "locality": "New Yorkhaven",
-        "region": "NY",
-        "postal_code": "10001",
-        "country": "US",
-        "language": "en",
-        "location": {
-            "latitude": 38.9382,
-            "longitude": -77.3349,
-            "accuracy": "Rooftop"
-        },
-        "status": "Verified"
-    },
-    "occupation": "Accountant",
+    "browser_url": "http://osdi-sample-system.org/organizations/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3",
+    "administrative_url": "http://osdi-sample-system.org/organizations/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/manage",
     "postal_addresses": [
         {
             "primary": true,
@@ -596,40 +463,35 @@ Cache-Control: max-age=0, private, must-revalidate
         }
     ],
     "custom_fields": {
-        "is_volunteer": "true",
-        "most_important_issue": "Equal pay",
-        "union_member": "true"
+        "most_important_issue": "Equal pay"
     },
     "_links": {
         "self": {
-            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3"
+            "href": "https://osdi-sample-system.org/api/v1/organizations/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3"
         },
         "osdi:answers": {
-            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/answers"
+            "href": "https://osdi-sample-system.org/api/v1/organizations/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/answers"
         },
         "osdi:attendance": {
-            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/attendance"
+            "href": "https://osdi-sample-system.org/api/v1/organizations/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/attendance"
         },
         "osdi:signatures": {
-            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/signatures"
+            "href": "https://osdi-sample-system.org/api/v1/organizations/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/signatures"
         },
         "osdi:submissions": {
-            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/submissions"
+            "href": "https://osdi-sample-system.org/api/v1/organizations/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/submissions"
         },
         "osdi:donations": {
-            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/donations"
+            "href": "https://osdi-sample-system.org/api/v1/organizations/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/donations"
         },
         "osdi:outreaches": {
-            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/outreaches"
+            "href": "https://osdi-sample-system.org/api/v1/organizations/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/outreaches"
         },
         "osdi:taggings": {
-            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/taggings"
+            "href": "https://osdi-sample-system.org/api/v1/organizations/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/taggings"
         },
         "osdi:items": {
-            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/items"
-        },
-        "osdi:record_canvass_helper": {
-            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/record_canvass_helper"
+            "href": "https://osdi-sample-system.org/api/v1/organizations/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/items"
         }
     }
 }
@@ -638,16 +500,14 @@ Cache-Control: max-age=0, private, must-revalidate
 _[Back to top...](#)_
 
 
-### Scenario: Creating a new person (POST)
+### Scenario: Creating a new organization (POST)
 
-Posting to the people collection endpoint will allow you to create a new person. The response is the new person that was created. While each implementing system will require different fields, any optional fields not included in a post operation should not be set at all by the receiving system, or should be set to default values.
-
-For information on how to link a person with tags and list subscription information in one post, see the [Person Signup Helper](person_signup.html) documentation.
+Posting to the organizations collection endpoint will allow you to create a new organization. The response is the new organization that was created. While each implementing system will require different fields, any optional fields not included in a post operation should not be set at all by the receiving system, or should be set to default values.
 
 #### Request
 
 ```javascript
-POST https://osdi-sample-system.org/api/v1/people/
+POST https://osdi-sample-system.org/api/v1/organizations/
 
 Header:
 OSDI-API-Token:[your api key here]
@@ -656,9 +516,7 @@ OSDI-API-Token:[your api key here]
     "identifiers": [
         "foreign_system:1"
     ],
-    "family_name": "Edwin",
     "given_name": "Labadie",
-    "additional_name": "Marques",
     "origin_system": "OpenSupporter",
     "email_addresses": [
         {
@@ -689,8 +547,7 @@ OSDI-API-Token:[your api key here]
             "number_type": "Mobile",
             "sms_capable": true
         }
-    ],
-    "gender": "Male"
+    ]
 }
 ```
 
@@ -709,12 +566,10 @@ Cache-Control: max-age=0, private, must-revalidate
     ],
     "created_date": "2014-03-20T21:04:31Z",
     "modified_date": "2014-03-20T21:04:31Z",
-    "family_name": "Edwin",
     "given_name": "Labadie",
-    "additional_name": "Marques",
     "origin_system": "OpenSupporter",
-    "browser_url": "http://osdi-sample-system.org/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3",
-    "administrative_url": "http://osdi-sample-system.org/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/manage",
+    "browser_url": "http://osdi-sample-system.org/organizations/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3",
+    "administrative_url": "http://osdi-sample-system.org/organizations/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/manage",
     "email_addresses": [
         {
             "address":"test-3@example.com",
@@ -745,37 +600,33 @@ Cache-Control: max-age=0, private, must-revalidate
             "sms_capable": true
         }
     ],
-    "gender": "Male",
     "_links": {
         "self": {
-            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse"
+            "href": "https://osdi-sample-system.org/api/v1/organizations/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse"
         },
         "osdi:answers": {
-            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/answers"
+            "href": "https://osdi-sample-system.org/api/v1/organizations/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/answers"
         },
         "osdi:attendance": {
-            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/attendance"
+            "href": "https://osdi-sample-system.org/api/v1/organizations/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/attendance"
         },
         "osdi:signatures": {
-            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/signatures"
+            "href": "https://osdi-sample-system.org/api/v1/organizations/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/signatures"
         },
         "osdi:submissions": {
-            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/submissions"
+            "href": "https://osdi-sample-system.org/api/v1/organizations/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/submissions"
         },
         "osdi:donations": {
-            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/donations"
+            "href": "https://osdi-sample-system.org/api/v1/organizations/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/donations"
         },
         "osdi:outreaches": {
-            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/outreaches"
+            "href": "https://osdi-sample-system.org/api/v1/organizations/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/outreaches"
         },
         "osdi:taggings": {
-            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/taggings"
+            "href": "https://osdi-sample-system.org/api/v1/organizations/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/taggings"
         },
         "osdi:items": {
-            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/items"
-        },
-        "osdi:record_canvass_helper": {
-            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/record_canvass_helper"
+            "href": "https://osdi-sample-system.org/api/v1/organizations/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/items"
         }
     }
 }
@@ -784,22 +635,22 @@ Cache-Control: max-age=0, private, must-revalidate
 _[Back to top...](#)_
 
 
-### Scenario: Modifying a person (PUT)
+### Scenario: Modifying a organization (PUT)
 
-You can update a person by calling a PUT operation on that person's endpoint. Your PUT should contain fields that you want to update. Missing fields will be ignored by the receiving system. Systems may also ignore PUT values, depending on whether fields you are trying to modify are read-only or not. You may set an attribute to nil by including the attribute using `nil` for value.
+You can update a organization by calling a PUT operation on that organization's endpoint. Your PUT should contain fields that you want to update. Missing fields will be ignored by the receiving system. Systems may also ignore PUT values, depending on whether fields you are trying to modify are read-only or not. You may set an attribute to nil by including the attribute using `nil` for value.
 
 {% include array_warning.md %}
 
 #### Request
 
 ```javascript
-PUT https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse
+PUT https://osdi-sample-system.org/api/v1/organizations/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse
 
 Header:
 OSDI-API-Token:[your api key here]
 
 {
-    "family_name": "Ed",
+    "given_name": "Ed",
     "email_addresses": [
         {
             "address":"test-new@example.com",
@@ -825,12 +676,10 @@ Cache-Control: max-age=0, private, must-revalidate
     ],
     "created_date": "2014-03-20T21:04:31Z",
     "modified_date": "2014-03-20T22:04:31Z",
-    "family_name": "Ed",
     "given_name": "Labadie",
-    "additional_name": "Marques",
     "origin_system": "OpenSupporter",
-    "browser_url": "http://osdi-sample-system.org/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3",
-    "administrative_url": "http://osdi-sample-system.org/people/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/manage",
+    "browser_url": "http://osdi-sample-system.org/organizations/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3",
+    "administrative_url": "http://osdi-sample-system.org/organizations/d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3/manage",
     "email_addresses": [
         {
             "address":"test-new@example.com",
@@ -861,37 +710,33 @@ Cache-Control: max-age=0, private, must-revalidate
             "sms_capable": true
         }
     ],
-    "gender": "Male",
     "_links": {
         "self": {
-            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse"
+            "href": "https://osdi-sample-system.org/api/v1/organizations/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse"
         },
         "osdi:answers": {
-            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/answers"
+            "href": "https://osdi-sample-system.org/api/v1/organizations/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/answers"
         },
         "osdi:attendance": {
-            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/attendance"
+            "href": "https://osdi-sample-system.org/api/v1/organizations/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/attendance"
         },
         "osdi:signatures": {
-            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/signatures"
+            "href": "https://osdi-sample-system.org/api/v1/organizations/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/signatures"
         },
         "osdi:submissions": {
-            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/submissions"
+            "href": "https://osdi-sample-system.org/api/v1/organizations/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/submissions"
         },
         "osdi:donations": {
-            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/donations"
+            "href": "https://osdi-sample-system.org/api/v1/organizations/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/donations"
         },
         "osdi:outreaches": {
-            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/outreaches"
+            "href": "https://osdi-sample-system.org/api/v1/organizations/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/outreaches"
         },
         "osdi:taggings": {
-            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/taggings"
+            "href": "https://osdi-sample-system.org/api/v1/organizations/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/taggings"
         },
         "osdi:items": {
-            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/items"
-        },
-        "osdi:record_canvass_helper": {
-            "href": "https://osdi-sample-system.org/api/v1/people/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/record_canvass_helper"
+            "href": "https://osdi-sample-system.org/api/v1/organizations/d91b4b2e-ae0e-4cd3-9ed7-de9uemdse/items"
         }
     }
 }
@@ -900,14 +745,14 @@ Cache-Control: max-age=0, private, must-revalidate
 _[Back to top...](#)_
 
 
-### Scenario: Deleting a person (DELETE)
+### Scenario: Deleting a organization (DELETE)
 
-You may delete a person by calling the DELETE command on the person's endpoint.
+You may delete a organization by calling the DELETE command on the organization's endpoint.
 
 #### Request
 
 ```javascript
-DELETE https://osdi-sample-system.org/api/v1/people/d32fcdd6-7366-466d-a3b8-7e0d87c3cd8b
+DELETE https://osdi-sample-system.org/api/v1/organizations/d32fcdd6-7366-466d-a3b8-7e0d87c3cd8b
 
 Header:
 OSDI-API-Token:[your api key here]
@@ -922,7 +767,7 @@ Content-Type: application/hal+json
 Cache-Control: max-age=0, private, must-revalidate
 
 {
-    "notice": "This person was successfully deleted."
+    "notice": "This organization was successfully deleted."
 }
 ```
 

--- a/petitions.md
+++ b/petitions.md
@@ -88,6 +88,7 @@ _[Back to top...](#)_
 |-----------    |-----------|-----------|--------------
 |self			|[Petition*](petitions.html)	|A self-referential link to the petition.
 |creator		|[Person*](people.html)  		|A link to a single Person resource representing the creator of the petition.
+|sponsors		|[Organizations[]*](organizations.html)  		|A link to a collection of Organization resources that are sponsoring or the organization(s) responsible for creating the petition.
 |modified_by	|[Person* ](people.html) 		|A link to a Person resource representing the last editor of this petition.
 |taggings     |[Taggings[]*](taggings.html) |A link to the collection of Tagging resources for this petition.
 |signatures		|[Signatures[]*](signatures.html)	|A link to the collection of Signature resources for this petition.

--- a/petitions.md
+++ b/petitions.md
@@ -88,7 +88,7 @@ _[Back to top...](#)_
 |-----------    |-----------|-----------|--------------
 |self			|[Petition*](petitions.html)	|A self-referential link to the petition.
 |creator		|[Person*](people.html)  		|A link to a single Person resource representing the creator of the petition.
-|sponsors		|[Organizations[]*](organizations.html)  		|A link to a collection of Organization resources that are sponsoring or the organization(s) responsible for creating the petition.
+|sponsor		|[Organization*](organizations.html)  		|A link to an Organization resource that is responsible for creating the petition and/or is the primary supporting/sponsoring organization.
 |modified_by	|[Person* ](people.html) 		|A link to a Person resource representing the last editor of this petition.
 |taggings     |[Taggings[]*](taggings.html) |A link to the collection of Tagging resources for this petition.
 |signatures		|[Signatures[]*](signatures.html)	|A link to the collection of Signature resources for this petition.

--- a/petitions.md
+++ b/petitions.md
@@ -217,6 +217,9 @@ Cache-Control: max-age=0, private, must-revalidate
                     "osdi:creator": {
                         "href": "https://osdi-sample-system.org/api/v1/people/65345d7d-cd24-466a-a698-4a7686ef684f"
                     },
+                    "osdi:sponsor": {
+                        "href": "https://osdi-sample-system.org/api/v1/organizations/5d7d6534-cd24-566a-98a6-ef684f4a7686"
+                    },
                     "osdi:modified_by": {
                         "href": "https://osdi-sample-system.org/api/v1/people/c945d6fe-929e-11e3-a2e9-12313d316c29"
                     },
@@ -255,6 +258,9 @@ Cache-Control: max-age=0, private, must-revalidate
                     },
                     "osdi:creator": {
                         "href": "https://osdi-sample-system.org/api/v1/people/65345d7d-cd24-466a-a698-4a7686ef684f"
+                    },
+                    "osdi:sponsor": {
+                        "href": "https://osdi-sample-system.org/api/v1/organizations/5d7d6534-cd24-566a-98a6-ef684f4a7686"
                     },
                     "osdi:modified_by": {
                         "href": "https://osdi-sample-system.org/api/v1/people/65345d7d-cd24-466a-a698-4a7686ef684f"
@@ -352,6 +358,9 @@ Cache-Control: max-age=0, private, must-revalidate
         "osdi:creator": {
             "href": "https://osdi-sample-system.org/api/v1/people/65345d7d-cd24-466a-a698-4a7686ef684f"
         },
+        "osdi:sponsor": {
+            "href": "https://osdi-sample-system.org/api/v1/organizations/5d7d6534-cd24-566a-98a6-ef684f4a7686"
+        },
         "osdi:taggings": {
             "href": "https://osdi-sample-system.org/api/v1/petitions/1efc3644-af25-4253-90b8-a0baf12dbd1e/taggings"
         },
@@ -419,6 +428,9 @@ Cache-Control: max-age=0, private, must-revalidate
         "osdi:creator": {
             "href": "https://osdi-sample-system.org/api/v1/people/65345d7d-cd24-466a-a698-4a7686ef684f"
         },
+        "osdi:sponsor": {
+            "href": "https://osdi-sample-system.org/api/v1/organizations/5d7d6534-cd24-566a-98a6-ef684f4a7686"
+        },
         "osdi:taggings": {
             "href": "https://osdi-sample-system.org/api/v1/petitions/1efc3644-af25-4253-90b8-a0baf12dbd1e/taggings"
         },
@@ -479,6 +491,9 @@ Cache-Control: max-age=0, private, must-revalidate
         },
         "osdi:creator": {
             "href": "https://osdi-sample-system.org/api/v1/people/65345d7d-cd24-466a-a698-4a7686ef684f"
+        },
+        "osdi:sponsor": {
+            "href": "https://osdi-sample-system.org/api/v1/organizations/5d7d6534-cd24-566a-98a6-ef684f4a7686"
         },
         "osdi:taggings": {
             "href": "https://osdi-sample-system.org/api/v1/petitions/1efc3644-af25-4253-90b8-a0baf12dbd1e/taggings"


### PR DESCRIPTION
This addresses issues #302 and #297  and also relates to existing PR #299
It's based on consensus reached on the OSDI tech all on 12/14/2017 which had the following agreements:
* Organizations should be a separate resource from Person to avoid confusion and mixing types in results from people queries
* However, Organization should be as similar to Person resource as possible -- many systems use the same table to store/track both
* ActionNetwork raised a use-case of having multiple organizations associated with events. Their terminology was 'sponsors' -- I have used that here -- though we should be clear wherever possible that this is 'sponsor' in the 'sponsor of a bill' sense rather than being necessarily funding-related.
* We decided to table membership and role affiliations for further extensions.  Those would be useful, but can build on this foundation.

Some things that people might want to explicitly note/comment on:
* using `organization` key as the primary field for name.  I think this is a twofer so that it's easy to test an object as an organization resource with the presence of that key (mostly), and also gets the most common value back.  Opinions may differ
* I have postponed adding `sponsors` as a link to *every* resource type (e.g. attendance, signature, etc), however I think that's a natural next step.
* For clarity and ease-of-understanding I separated out the Person-common fields and the Organization-specific fields in the spec.  However, perhaps that's more confusing than useful?

For reviewers, I split the work into three commits.  The first just copies the Person file to organizations.md.  That makes it easy to see the differences from people.md vs. organizations.md in the second commit.  The third focuses on examples. etc.
