### PR TITLE
WIP Proposal for People Import Helper

### DIFF
--- a/_includes/helper_action_examples_short.md
+++ b/_includes/helper_action_examples_short.md
@@ -1,0 +1,17 @@
+{%- capture examples -%}
+"add_tags": [
+    "volunteer",
+    "donor"
+],
+"add_lists": [
+    "supporters"
+],
+"add_questions_responses_uri": [
+  {
+    "question": "https://osdi-sample-system.org/api/v1/questions/c945d6fe-929e-11e3-a2e9-12313d316c29",
+    "responses": [ "r1", "r2", "r2"]
+  }
+]{%- endcapture -%}
+{%- assign examples_lines = examples | newline_to_br | strip_newlines | split: '<br />' -%}
+{% for line in examples_lines %}{{ line | prepend: include.prefix }}
+{% endfor %}

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -36,6 +36,7 @@
     <li><a href="{{ site.baseurl }}/wrappers.html">Wrappers</a></li>    
 	<li class="nav-header">Helpers</li> 
     <li><a href="{{ site.baseurl }}/person_signup.html">Person Signup Helper</a></li>
+    <li><a href="{{ site.baseurl }}/people_import_helper.html">People Import Helper</a></li>
     <li><a href="{{ site.baseurl }}/record_attendance.html">Record Attendance Helper</a></li>
     <li><a href="{{ site.baseurl }}/record_canvass.html">Record Canvass Helper</a></li>
     <li><a href="{{ site.baseurl }}/record_donation.html">Record Donation Helper</a></li>

--- a/people.md
+++ b/people.md
@@ -193,6 +193,7 @@ _[Back to top...](#)_
 |Name          |Description
 |-----------    |-----------
 |[person_signup_helper](person_signup.html)      |Allows the creation of a person and associated tag and list membership.
+|[people_import_helper](people_import_helper.html)  |Allows a batch of people to be created or updated.
 
 _[Back to top...](#)_
 
@@ -200,6 +201,7 @@ _[Back to top...](#)_
 ## Related Resources
 
 * [Person Signup Helper](person_signup.html)
+* [People Import Helper](people_import_helper.html)
 * [Donation](#)
 * [Submission](submissions.html)
 * [Attendance](attendances.html)

--- a/people_import_helper.md
+++ b/people_import_helper.md
@@ -1,0 +1,343 @@
+---
+layout: default
+title: People Import Helper
+---
+
+# People Import Helper
+
+This  document defines the People Import Helper resource.
+
+The People import helper is a helper endpoint to aid in the import of a batch of [People](people.html) resources via POST. It provides a quick and easy way to add multiple people to an OSDI system.
+
+The collection of people to be imported is represented in an array with the attribute name "signups".  Each element in the signups array is equivalent to the representation of a Person Signup Helper request.
+
+Some systems may attempt to match inputs via the People import helper to existing people in the database and update their record instead of creating a new person for every POST. The method used for matching will be detailed in that system's documentation.
+
+The response to a successful People import helper POST is an empty body, if there were no errors on any of the signups.
+
+If errors occurred on individual signups, the response should contain an ````osdi:error```` object for batch requests indicating the individual status information.
+
+### Sections:
+
+* [Endpoints and URL structures](#endpoints-and-url-structures)
+* [Fields](#fields)
+    * [People import helper Fields](#people-import-helper-fields)
+    * [Helper Action Functions](#helper-action-functions)
+    * [Related Objects](#related-objects)
+* [Related Resources](#related-resources)
+* [Scenarios](#scenarios)
+    * [Scenario: Importing People With Errors (POST)](#scenario-importing-people-with-errors-post)
+    * [Scenario: Importing People Without Errors (POST)](#scenario-importing-people-without-errors-post)
+    
+
+{% include endpoints_and_url_structures.md %}
+
+The link relation label for the People import helper is ```osdi:people_import_helper```.
+
+_[Back to top...](#)_
+
+
+## Fields
+
+{% include fields_intro.md %}
+
+### People import helper Fields
+
+A list of fields specific for POSTing via the People import helper.
+
+|Name          |Type      |Description
+|-----------    |-----------|--------------
+|signups         |[PersonSignupHelper[]](person_signup.html) |An array of Person Signup Helper request representations.
+
+{% include control_headers.md %}
+
+### Import Response Fields
+
+A list of fields for the response to People import helper.
+
+|Name          |Type      |Description
+|-----------    |-----------|--------------
+|statistics     |object   | A vendor defined se
+
+
+_[Back to top...](#)_
+
+### Helper Action Functions
+
+{% include helper_action_functions.md %}
+
+_[Back to top...](#)_
+
+### Related Objects
+
+These JSON hashes included in the table above are broken out into their own tables for readability, rather than independent resources with their own endpoints.
+
+#### Statistics
+
+|Name          |Type      |Description
+|-----------    |-----------|--------------
+
+
+## Related Resources
+
+* [Person](people.html)
+* [PersonSignupHelper](person_signup.html)
+
+_[Back to top...](#)_
+
+
+## Scenarios
+
+{% include scenarios_helper_intro.md %}
+
+
+### Scenario: Importing People With Errors (POST)
+
+Posting to the people import helper endpoint will allow you to upload a collection of people, as well as invoke helper action functions to add tags, lists, etc., for each person.
+
+#### Request
+
+```javascript
+POST https://osdi-sample-system.org/api/v1/people/people_import_helper
+
+Header:
+OSDI-API-Token:[your api key here]
+
+{
+    "signups": [
+        {
+            "person": {
+                "identifiers": [
+                    "foreign_system:1"
+                ],
+                "family_name": "Edwin",
+                "given_name": "Labadie",
+                "additional_name": "Marques",
+                "origin_system": "OpenSupporter",
+                "email_addresses": [
+                    {
+                        "address":"test-3@example.com",
+                        "primary": true,
+                        "address_type": "Personal"
+                    }
+                ],
+            },
+{% include helper_action_examples_short.md prefix="            " %}
+        },
+        {
+            "person": {
+                "identifiers": [
+                    "osdi_sample_system:d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3",
+                    "foreign_system:1"
+                ],
+                "origin_system": "OSDI Sample System",
+                "created_date": "2014-03-20T21:04:31Z",
+                "modified_date": "2014-03-20T21:04:31Z",
+                "given_name": "John",
+                "family_name": "Smith",
+                "honorific_prefix": "Mx.",
+                "honorific_suffix": "Ph.D",
+                "email_addresses": [
+                    {
+                        "primary": true,
+                        "address": "johnsmith@mail.com",
+                        "address_type": "Personal",
+                        "status": "subscribed"
+                    }
+                ],
+                "phone_numbers": [
+                  {
+                    "number": "1-800-OSDI-RULES",
+                    "number_type": "Home"
+                  }
+                ]
+            },
+{% include helper_action_examples_short.md prefix="            " %}
+        }
+    ]
+}
+```
+
+#### Response
+
+```javascript
+207 Multistatus
+
+Content-Type: application/hal+json
+Cache-Control: max-age=0, private, must-revalidate
+
+{
+  "osdi:error": {
+    "request_type": "batch",
+    "response_code": 200,
+    "batch_errors": [
+      {
+        "request_type": "non-atomic",
+        "response_code": 207,
+        "resource_status": [
+          {
+            "resource": "osdi:person",
+            "response_code": 201
+          },
+          {
+            "resource": "osdi:tagging",
+            "response_code": 400,
+            "errors": [
+              {
+                "code": "TAG_NAME_DOES_NOT_EXIST",
+                "description": "The tag name 'volunteer' does not exist.",
+                "properties": [ 'add_tags' ]
+              },
+            ]
+          },
+        ]
+      },
+      {
+        "request_type": "non-atomic",
+        "response_code": 400,
+        "resource_status": [
+          {
+            "resource": "osdi:person",
+            "response_code": 400,
+            "errors": [
+              {
+                "code": "INVALID PHONE NUMBER",
+                "description": "The phone number '1-800-OSDI-RULES' is not a valid phone number.",
+                "properties": [ 'phone_numbers[0].number' ]
+              },
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+_[Back to top...](#)_
+
+
+### Scenario: Importing People Without Errors (POST)
+
+Posting to the people import helper endpoint will allow you to upload a collection of people, as well as invoke helper action functions to add tags, lists, etc., for each person.
+
+#### Request
+
+```javascript
+POST https://osdi-sample-system.org/api/v1/people/people_import_helper
+
+Header:
+OSDI-API-Token:[your api key here]
+
+{
+    "signups": [
+        {
+            "person": {
+                "identifiers": [
+                    "foreign_system:1"
+                ],
+                "family_name": "Edwin",
+                "given_name": "Labadie",
+                "additional_name": "Marques",
+                "origin_system": "OpenSupporter",
+                "email_addresses": [
+                    {
+                        "address":"test-3@example.com",
+                        "primary": true,
+                        "address_type": "Personal"
+                    }
+                ],
+            },
+{% include helper_action_examples_short.md prefix="            " %}
+        },
+        {
+            "person": {
+                "identifiers": [
+                    "osdi_sample_system:d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3",
+                    "foreign_system:1"
+                ],
+                "origin_system": "OSDI Sample System",
+                "created_date": "2014-03-20T21:04:31Z",
+                "modified_date": "2014-03-20T21:04:31Z",
+                "given_name": "John",
+                "family_name": "Smith",
+                "honorific_prefix": "Mx.",
+                "honorific_suffix": "Ph.D",
+                "email_addresses": [
+                    {
+                        "primary": true,
+                        "address": "johnsmith@mail.com",
+                        "address_type": "Personal",
+                        "status": "subscribed"
+                    }
+                ],
+                "phone_numbers": [
+                  {
+                    "number": "1-800-OSDI-RULES",
+                    "number_type": "Home"
+                  }
+                ]
+            },
+{% include helper_action_examples_short.md prefix="            " %}
+        }
+    ]
+}
+```
+
+#### Response
+
+```javascript
+200 OK
+
+Content-Type: application/hal+json
+Cache-Control: max-age=0, private, must-revalidate
+
+{
+  "osdi:error": {
+    "request_type": "batch",
+    "response_code": 200,
+    "batch_errors": [
+      {
+        "request_type": "non-atomic",
+        "response_code": 207,
+        "resource_status": [
+          {
+            "resource": "osdi:person",
+            "response_code": 201
+          },
+          {
+            "resource": "osdi:tagging",
+            "response_code": 400,
+            "errors": [
+              {
+                "code": "TAG_NAME_DOES_NOT_EXIST",
+                "description": "The tag name 'volunteer' does not exist.",
+                "properties": [ 'add_tags' ]
+              },
+            ]
+          },
+        ]
+      },
+      {
+        "request_type": "non-atomic",
+        "response_code": 400,
+        "resource_status": [
+          {
+            "resource": "osdi:person",
+            "response_code": 400,
+            "errors": [
+              {
+                "code": "INVALID PHONE NUMBER",
+                "description": "The phone number '1-800-OSDI-RULES' is not a valid phone number.",
+                "properties": [ 'phone_numbers[0].number' ]
+              },
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+_[Back to top...](#)_

--- a/people_import_helper.md
+++ b/people_import_helper.md
@@ -58,6 +58,12 @@ A list of fields for the response to People import helper.
 |Name          |Type      |Description
 |-----------    |-----------|--------------
 |statistics     |object   | A vendor defined se
+|submitted    | integer | A count of submitted records
+|processed    | integer | A count of successfully processed records
+|errors       | integer | A count of records which caused errors
+|updated      | integer | A count of updated records
+|created      | integer | A count of newly created records
+|osdi:error   | OsdiError| OPTIONAL details of errors
 
 
 _[Back to top...](#)_
@@ -160,13 +166,16 @@ OSDI-API-Token:[your api key here]
 
 #### Response
 
-```javascript
+````json
 207 Multistatus
 
 Content-Type: application/hal+json
 Cache-Control: max-age=0, private, must-revalidate
 
 {
+  "submitted": 2,
+  "successful": 1,
+  "errors": 1,
   "osdi:error": {
     "request_type": "batch",
     "response_code": 200,
@@ -212,7 +221,7 @@ Cache-Control: max-age=0, private, must-revalidate
     ]
   }
 }
-```
+````
 
 _[Back to top...](#)_
 
@@ -223,7 +232,7 @@ Posting to the people import helper endpoint will allow you to upload a collecti
 
 #### Request
 
-```javascript
+```json
 POST https://osdi-sample-system.org/api/v1/people/people_import_helper
 
 Header:
@@ -286,13 +295,16 @@ OSDI-API-Token:[your api key here]
 
 #### Response
 
-```javascript
+````json
 200 OK
 
 Content-Type: application/hal+json
 Cache-Control: max-age=0, private, must-revalidate
 
 {
+  "submitted": 2,
+  "successful": 1,
+  "errors": 1,
   "osdi:error": {
     "request_type": "batch",
     "response_code": 200,
@@ -313,9 +325,9 @@ Cache-Control: max-age=0, private, must-revalidate
                 "code": "TAG_NAME_DOES_NOT_EXIST",
                 "description": "The tag name 'volunteer' does not exist.",
                 "properties": [ 'add_tags' ]
-              },
+              }
             ]
-          },
+          }
         ]
       },
       {
@@ -330,7 +342,7 @@ Cache-Control: max-age=0, private, must-revalidate
                 "code": "INVALID PHONE NUMBER",
                 "description": "The phone number '1-800-OSDI-RULES' is not a valid phone number.",
                 "properties": [ 'phone_numbers[0].number' ]
-              },
+              }
             ]
           }
         ]
@@ -338,6 +350,6 @@ Cache-Control: max-age=0, private, must-revalidate
     ]
   }
 }
-```
+````
 
 _[Back to top...](#)_


### PR DESCRIPTION
Based on the need of apps like Spoke or CRMs to have people imported in batches vs single API call per person, this is a proposal for a new helper osdi:people_import_helper.  It's been prototyped as a Spoke contacts API with links below.

This helper allows a client to essentially batch up a set of person_signup_helper object into an array and upload all at once. By wrapping the signup objects, rather than an array of people, this allows the helper action functions like add_tags et al to be invoked individually for each person in the array.

The implementation could use the same endpoint for the osdi:person_signup_helper and osdi:people_import_helper but parse the body and behave accordingly.  This allows a client to discover if it can do a batched import, or if it must go through the pain of individually uploading each person.

As for the response to the batch helper, I think Larry has the right idea.  The response should be status information on errors/validation failures.  We currently have osdi:error defined which could be a good way to represent this, and the data Larry's code is returning.  I've added a new attribute within osdi:errors to accommodate batch requests.

I've added some stats attributes to the response object as a stake in the ground, but am interested in hearing what others think about what's necessary.  Please let me know

LINKS
Larry, @lperson original PR:  https://github.com/MoveOnOrg/Spoke/pull/967
Josh's OSDI-ifying branch:  https://github.com/MoveOnOrg/Spoke/compare/main...joshco:osdi_contacts
GHP Formatted spec for person_import_helper:  https://joshco.github.io/osdi-docs/people_import_helper.html